### PR TITLE
Thread-safe handler, better event loop

### DIFF
--- a/api/room_membership.go
+++ b/api/room_membership.go
@@ -148,7 +148,7 @@ func (c *Client) Kick(roomID matrix.RoomID, userID matrix.UserID, reason string)
 // Ban bans the user from the provided room.
 //
 // It implements the `POST /_matrix/client/r0/rooms/{roomId}/ban` endpoint.
-func (c *Client) Ban(roomID matrix.RoomID, userID string, reason string) error {
+func (c *Client) Ban(roomID matrix.RoomID, userID matrix.UserID, reason string) error {
 	param := struct {
 		UserID matrix.UserID `json:"user_id"`
 		Reason string        `json:"reason,omitempty"`
@@ -172,7 +172,7 @@ func (c *Client) Ban(roomID matrix.RoomID, userID string, reason string) error {
 // Unban unbans the user from the provided room.
 //
 // It implements the `POST /_matrix/client/r0/rooms/{roomId}/unban` endpoint.
-func (c *Client) Unban(roomID matrix.RoomID, userID string) error {
+func (c *Client) Unban(roomID matrix.RoomID, userID matrix.UserID) error {
 	param := struct {
 		UserID matrix.UserID `json:"user_id"`
 	}{userID}

--- a/client.go
+++ b/client.go
@@ -21,9 +21,8 @@ type Client struct {
 	Handler Handler
 	State   State
 
-	nextRetryTime int
-	cancelFunc    func()
-	closeDone     chan struct{}
+	cancelFunc func()
+	closeDone  chan struct{}
 }
 
 // New creates a client with the provided host URL and the default HTTP client.


### PR DESCRIPTION
This commit adds a RWMutex into the handler code to make it thread-safe.
It also added a proper contextful timer for graceful cancellation and
cleanup, as well as minor modifications to potentially speed things up.

This commit also fixes a compile error in package api, presumably caused
by a prior mistake.