### PR TITLE
Fix DiscoveryInfo getting nil Context

### DIFF
--- a/api/discovery.go
+++ b/api/discovery.go
@@ -59,7 +59,7 @@ func (c *Client) DiscoveryInfo() (*DiscoveryInfoResponse, error) {
 	}
 
 	// Probe provided homeserver to make sure it's valid.
-	checkClient := &Client{}
+	checkClient := &Client{Client: c.Client}
 	checkClient.HomeServer = parsedURL.Host
 
 	_, err = checkClient.SupportedVersions()


### PR DESCRIPTION
This pull request fixes `(*api.Client).DiscoveryInfo` erroring out about `net/http: nil Context`.