### PR TITLE
Allow State to store any events from Sync

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,6 +21,7 @@ type Client struct {
 	Handler Handler
 	State   State
 
+	next       string
 	cancelFunc func()
 	closeDone  chan struct{}
 }

--- a/state.go
+++ b/state.go
@@ -3,6 +3,7 @@ package gotrix
 import (
 	"errors"
 
+	"github.com/chanbakjsd/gotrix/api"
 	"github.com/chanbakjsd/gotrix/event"
 	"github.com/chanbakjsd/gotrix/matrix"
 )
@@ -16,12 +17,13 @@ type State interface {
 	// RoomState returns the latest event in a room with the specified type.
 	// If it is found in the cache, error will be nil.
 	// Note that (nil, nil) should be returned if the cache can be certain the event type never occurred.
-	RoomState(roomID matrix.RoomID, eventType event.Type, stateKey string) (e event.StateEvent, err error)
+	RoomState(roomID matrix.RoomID, eventType event.Type, stateKey string) (event.StateEvent, error)
 	// RoomStates returns all the events with the given event type.
 	// If there is duplicate events with the same state key, the newer one should be returned.
 	RoomStates(roomID matrix.RoomID, eventType event.Type) (map[string]event.StateEvent, error)
-	// RoomStateSet creates a room event in the specified room.
-	RoomStateSet(roomID matrix.RoomID, e event.StateEvent) error
+	// AddEvent adds the needed events from the given sync response.
+	// It is up to the implementation to pick and add the needed events inside the response.
+	AddEvents(*api.SyncResponse) error
 }
 
 // RoomState queries the internal State for the given RoomEvent.

--- a/syncLoop.go
+++ b/syncLoop.go
@@ -86,7 +86,7 @@ func (c *Client) handleWithRoomID(e []event.RawEvent, roomID matrix.RoomID, isHi
 
 		c.Handler.HandleRaw(c, v)
 		if err != nil {
-			return
+			continue
 		}
 		c.Handler.Handle(c, concrete)
 	}
@@ -105,6 +105,8 @@ func (c *Client) readLoop(ctx context.Context, filter string) {
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 
+	defer close(c.closeDone)
+
 	<-timer.C
 
 	for {
@@ -118,7 +120,6 @@ func (c *Client) readLoop(ctx context.Context, filter string) {
 		if err != nil {
 			if ctx.Err() != nil {
 				// The context has finished.
-				close(c.closeDone)
 				return
 			}
 			// Exponentially backoff with a cap of 5 minutes.


### PR DESCRIPTION
This commit breaks the old State interface to replace the old
RoomEventSet method with the new AddEvents method, which allows a state
implementation to store any events it wants, including timeline events.

The default state implementation (DefaultState) will still behave as it
used to be.
