### PR TITLE
fix: OpenWithNext not using next

### DIFF
--- a/syncLoop.go
+++ b/syncLoop.go
@@ -61,7 +61,7 @@ func (c *Client) OpenWithNext(next string) error {
 	if err != nil {
 		return err
 	}
-	go c.readLoop(ctx, filterID)
+	go c.readLoop(ctx, next, filterID)
 
 	return nil
 }
@@ -101,9 +101,8 @@ func (c *Client) handleWithRoomID(e []event.RawEvent, roomID matrix.RoomID, isHi
 	}
 }
 
-func (c *Client) readLoop(ctx context.Context, filter string) {
+func (c *Client) readLoop(ctx context.Context, next, filter string) {
 	client := c.WithContext(ctx)
-	next := ""
 
 	handle := func(e []event.RawEvent) {
 		c.handleWithRoomID(e, "", next == "")


### PR DESCRIPTION
This pull request fixes the `OpenWithNext()` method not actually using the given `next` string.