### PR TITLE
feat: Add NewContent into RoomMessageEvent

### DIFF
--- a/event/im_message.go
+++ b/event/im_message.go
@@ -21,6 +21,8 @@ type RoomMessageEvent struct {
 
 	// This message is a reply to RelatesTo if present.
 	RelatesTo json.RawMessage `json:"m.relates_to,omitempty"`
+	// NewContent is the new message content if RelatesTo.RelType is m.replace.
+	NewContent *RoomMessageEvent `json:"m.new_content,omitempty"`
 
 	// Optionally present in Text, Emote and Notice.
 	Format        MessageFormat `json:"format,omitempty"`


### PR DESCRIPTION
This commit adds the NewContent field into RoomMessageEvent. It is
supposed to be an object with the same type as RoomMessageEvent and
usually contains the message information that will replace the old
event's body.

For reference, here's an example JSON:

```json
{
  "content": {
    "body": " * b",
    "m.new_content": {
      "body": "b",
      "msgtype": "m.text"
    },
    "m.relates_to": {
      "event_id": "$eventID",
      "rel_type": "m.replace"
    },
    "msgtype": "m.text"
  }
}
```