### PR TITLE
Add Redacts into RoomRedactionEvent

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -45,7 +45,7 @@ type RawEvent struct {
 	PrevContent json.RawMessage `json:"prev_content,omitempty"` // Optional previous content, if available.
 
 	// Data for `m.room.redaction`. The ID of the event that was actually redacted.
-	Redacts string `json:"redacts,omitempty"`
+	Redacts matrix.EventID `json:"redacts,omitempty"`
 }
 
 // Event is a parsed instance of events in Matrix.

--- a/event/room.go
+++ b/event/room.go
@@ -154,7 +154,21 @@ type RoomPowerLevelsEvent struct {
 type RoomRedactionEvent struct {
 	RoomEventInfo `json:"-"`
 
-	Reason string `json:"reason,omitempty"`
+	Redacts matrix.EventID `json:"-"`
+	Reason  string         `json:"reason,omitempty"`
+}
+
+func parseRoomRedactionEvent(e RawEvent) (Event, error) {
+	c := RoomRedactionEvent{
+		RoomEventInfo: e.toRoomEventInfo(),
+		Redacts:       e.Redacts,
+	}
+
+	if err := json.Unmarshal(e.Content, &c); err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
 // Type satisfies StateEvent.

--- a/event/type.go
+++ b/event/type.go
@@ -57,7 +57,7 @@ var parser = map[Type]func(RawEvent) (Event, error){
 	TypeRoomJoinRules:      roomEventParse(func() eventWithRoomEventInfo { return new(RoomJoinRulesEvent) }),
 	TypeRoomMember:         parseRoomMemberEvent,
 	TypeRoomPowerLevels:    roomEventParse(func() eventWithRoomEventInfo { return new(RoomPowerLevelsEvent) }),
-	TypeRoomRedaction:      roomEventParse(func() eventWithRoomEventInfo { return new(RoomRedactionEvent) }),
+	TypeRoomRedaction:      parseRoomRedactionEvent,
 
 	TypeRoomMessage: roomEventParse(func() eventWithRoomEventInfo { return new(RoomMessageEvent) }),
 	TypeRoomName:    roomEventParse(func() eventWithRoomEventInfo { return new(RoomNameEvent) }),


### PR DESCRIPTION
This commit adds the Redacts field (type matrix.EventID) into the
RoomRedactionEvent struct.

It also changes the type of the RawEvent.Redacts field ot be a
matrix.EventID as well, so it is a breaking change.