### PR TITLE
Fix httputil.NewCustomClient not having ctx

### DIFF
--- a/api/httputil/client.go
+++ b/api/httputil/client.go
@@ -42,6 +42,7 @@ func NewClient() Client {
 func NewCustomClient(d ClientDriver) Client {
 	return Client{
 		ClientDriver: d,
+		ctx:          context.Background(),
 	}
 }
 


### PR DESCRIPTION
Using this function without `WithContext` before this fix will likely cause a program panic down the line. This PR fixes that.