### PR TITLE
NextTransactionID no longer needs a goroutine

### DIFF
--- a/api/util.go
+++ b/api/util.go
@@ -3,33 +3,26 @@ package api
 import (
 	"encoding/base64"
 	"math/rand"
+	"sync"
 	"time"
 )
 
-var transactionID = make(chan string)
+var (
+	localRand   = rand.New(rand.NewSource(time.Now().UnixNano()))
+	localRandMu sync.Mutex
+)
 
 // NextTransactionID retrieves the next transaction ID to use.
 func NextTransactionID() string {
-	return <-transactionID
-}
+	var bytes [16]byte
 
-func init() {
-	go generateTransactionID()
-}
+	localRandMu.Lock()
+	_, err := localRand.Read(bytes[:])
+	localRandMu.Unlock()
 
-// generateTransactionID saturates the transactionID channel with new IDs.
-// This minifies the possibility that a transaction ID collision happening.
-func generateTransactionID() {
-	// localRand is an instance of random so global random is not affected.
-	// It is intentionally not cryptographically secure to make it faster.
-	localRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	for {
-		var bytes [16]byte
-		_, err := localRand.Read(bytes[:])
-		if err != nil {
-			panic(err)
-		}
-		transactionID <- base64.RawURLEncoding.EncodeToString(bytes[:])
+	if err != nil {
+		panic(err)
 	}
+
+	return base64.RawURLEncoding.EncodeToString(bytes[:])
 }


### PR DESCRIPTION
This PR changes `NextTransactionID` to use a mutex and a `rand.Rand` globally instead of using a generator goroutine. It clears up the stack trace a bit when everything panics.

`math/rand`'s default global source uses a mutex similar to this, so doing this makes sense, I think.