### PR TITLE
Add encrypt.Client

### DIFF
--- a/api/sync.go
+++ b/api/sync.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -21,13 +22,31 @@ type SyncArg struct {
 // SyncResponse represents the response of a sync API call consisting of every info the server
 // updates the client on.
 type SyncResponse struct {
-	NextBatch              string          `json:"next_batch"`
-	Presence               SyncEvents      `json:"presence,omitempty"`
-	AccountData            SyncEvents      `json:"account_data,omitempty"`
-	Rooms                  SyncRoomEvents  `json:"rooms,omitempty"`
-	ToDevice               SyncEvents      `json:"to_device,omitempty"`
-	DeviceLists            SyncDeviceLists `json:"device_lists,omitempty"`
-	DeviceOneTimeKeysCount map[string]int  `json:"device_one_time_keys_count,omitempty"`
+	NextBatch   string         `json:"next_batch"`
+	Presence    SyncEvents     `json:"presence,omitempty"`
+	AccountData SyncEvents     `json:"account_data,omitempty"`
+	Rooms       SyncRoomEvents `json:"rooms,omitempty"`
+	ToDevice    SyncEvents     `json:"to_device,omitempty"`
+
+	raw json.RawMessage
+}
+
+// UnmarshalJSON unmarshals b into r and fills the raw JSON.
+func (r *SyncResponse) UnmarshalJSON(b []byte) error {
+	type raw SyncResponse
+
+	if err := json.Unmarshal(b, (*raw)(r)); err != nil {
+		return err
+	}
+
+	r.raw = append([]byte(nil), b...)
+	return nil
+}
+
+// Raw returns the original JSON that the SyncResponse was unmarshaled on with. It may be nil if the
+// SyncResponse is not originally unmarshaled from.
+func (r *SyncResponse) Raw() []byte {
+	return r.raw
 }
 
 // SyncRoomEvents consists of events that are tied to specific rooms (like messages and typing

--- a/encrypt/client.go
+++ b/encrypt/client.go
@@ -1,0 +1,308 @@
+package encrypt
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/chanbakjsd/gotrix/api"
+	"github.com/chanbakjsd/gotrix/api/httputil"
+	"github.com/chanbakjsd/gotrix/matrix"
+)
+
+// Client wraps around an api.Client to provide additional encryption endpoint calls.
+type Client struct {
+	api.Client
+}
+
+// KeyChanges is returned by encrypt.Client.KeyChanges.
+type KeyChanges struct {
+	Changed []matrix.UserID `json:"changed"`
+	Left    []matrix.UserID `json:"left"`
+}
+
+// KeyChanges Gets a list of users who have updated their device identity keys since a previous sync
+// token.
+//
+// Parameters:
+//
+//    - from: required, the desired start point of the list. Should be the next_batch field from a
+//      response to an earlier call to /sync. Users who have not uploaded new device identity keys
+//      since this point, nor deleted existing devices with identity keys since then, will be
+//      excluded from the results.
+//    - to: required, the desired end point of the list. Should be the next_batch field from a
+//      recent call to /sync - typically the most recent such call. This may be used by the server
+//      as a hint to check its caches are up to date.
+//
+func (c *Client) KeyChanges(from, to string) (*KeyChanges, error) {
+	var resp KeyChanges
+
+	err := c.Request(
+		"GET", EndpointKeysChanges, &resp,
+		httputil.WithToken(),
+		httputil.WithQuery(map[string]string{
+			"from": from,
+			"to":   to,
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// KeyClaims contains the keys to be claimed. It maps from device ID to algorithm name.
+type KeyClaims map[matrix.UserID]string
+
+// KeyClaimResponse is returned by encrypt.Client.KeyClaim.
+type KeyClaimResponse struct {
+	OneTimeKeys OneTimeUserDeviceKeys `json:"one_time_keys"`
+	// TODO: Failures, but the exact type is not documented.
+}
+
+// OneTimeUserDeviceKeys is the map of one-time keys for the queried devices. It maps the user ID
+// given to Client.KeyClaim to a map that maps the device ID to the user-device keys.
+type OneTimeUserDeviceKeys map[matrix.UserID]map[matrix.DeviceID]OneTimeKeys
+
+// OneTimeKeys maps an object with key "<algorithm>:<keyID>" to the user-device key object.
+type OneTimeKeys map[string]json.RawMessage
+
+// NewOneTimeKeys creates a map of one-time keys from the given two key maps.
+func NewOneTimeKeys(
+	unsigned map[Algorithm]map[matrix.DeviceID]Key,
+	signed map[Algorithm]map[matrix.DeviceID]OneTimeSignedKey) OneTimeKeys {
+
+	otk := OneTimeKeys{}
+
+	for algo, devices := range unsigned {
+		for device, key := range devices {
+			b, err := json.Marshal(key)
+			if err != nil {
+				panic("cannot marshal unsigned key: " + err.Error())
+			}
+			otk[string(algo)+":"+string(device)] = b
+		}
+	}
+
+	for algo, devices := range signed {
+		for device, key := range devices {
+			b, err := json.Marshal(key)
+			if err != nil {
+				panic("cannot marshal signed key: " + err.Error())
+			}
+			otk[string(algo)+":"+string(device)] = b
+		}
+	}
+
+	return otk
+}
+
+// Key gets the unsigned key from the given signature algorithm type and key ID.
+func (ks OneTimeKeys) Key(algorithm SignatureAlgorithm, keyID string) (Key, error) {
+	raw := ks.RawKey(algorithm.SignedAlgorithm(), keyID)
+	if raw == nil {
+		return "", fmt.Errorf("no key with ID %q found", keyID)
+	}
+
+	var key Key
+
+	if err := json.Unmarshal(raw, &key); err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+// SignedKey gets the signed key from the given signature algorithm type and key ID. The user does
+// not have to call SignedAlgorithm on the given algorithm.
+func (ks OneTimeKeys) SignedKey(algorithm SignatureAlgorithm, keyID string) (OneTimeSignedKey, error) {
+	raw := ks.RawKey(algorithm.SignedAlgorithm(), keyID)
+	if raw == nil {
+		return OneTimeSignedKey{}, fmt.Errorf("no key with ID %q found", keyID)
+	}
+
+	var otk OneTimeSignedKey
+
+	if err := json.Unmarshal(raw, &otk); err != nil {
+		return OneTimeSignedKey{}, err
+	}
+
+	return otk, nil
+}
+
+// RawKey gets the key value as raw JSON from the given signature algorithm type and key ID.
+func (ks OneTimeKeys) RawKey(algorithm SignatureAlgorithm, keyID string) json.RawMessage {
+	return ks[string(algorithm)+":"+keyID]
+}
+
+// OneTimeSignedKey describes the value type of a "signed" key.
+type OneTimeSignedKey struct {
+	Key        Key
+	Signatures UserSignatures
+}
+
+// DeviceAlgorithmKey combines both the signature algorithm and device ID to form a colon-delimited
+// key string used in the API. It has the format "<algorithm>:<deviceID>".
+type DeviceAlgorithmKey string
+
+// NewDeviceAlgorithmKey creates a newly-formatted DeviceAlgorithmKey.
+func NewDeviceAlgorithmKey(deviceID matrix.DeviceID, algorithm SignatureAlgorithm) DeviceAlgorithmKey {
+	return DeviceAlgorithmKey(string(algorithm) + ":" + string(deviceID))
+}
+
+// UserSignatures maps from user ID to a map of "<algorithm>:<deviceID>" to a signature.
+type UserSignatures map[matrix.UserID]map[DeviceAlgorithmKey]Signature
+
+// Signature gets the signature for the given user, device and algorithm.
+func (s UserSignatures) Signature(uID matrix.UserID, deviceID matrix.DeviceID, algorithm SignatureAlgorithm) Signature {
+	return s[uID][NewDeviceAlgorithmKey(deviceID, algorithm)]
+}
+
+// KeyClaim claims one-time keys for use in pre-key messages. The timeout has an accuracy of 1ms.
+//
+// Parameters:
+//
+//    - oneTimeKeys: required, the keys to be claimed. A map from user ID, to a map from device ID
+//      to algorithm name.
+//    - timeout: the time to wait when downloading keys from remote servers. 10 seconds is the
+//      recommended default.
+//
+func (c *Client) KeyClaim(userClaims map[matrix.UserID]KeyClaims, timeout time.Duration) (*KeyClaimResponse, error) {
+	req := struct {
+		OneTimeKeys map[matrix.UserID]KeyClaims `json:"one_time_keys"`
+		Timeout     int                         `json:"timeout,omitempty"`
+	}{
+		OneTimeKeys: userClaims,
+		Timeout:     int(timeout / time.Millisecond),
+	}
+
+	var resp KeyClaimResponse
+
+	err := c.Request(
+		"GET", EndpointKeysClaim, &resp,
+		httputil.WithToken(),
+		httputil.WithJSONBody(req),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// KeyQueryResponse is returned from encrypt.Client.KeyQuery.
+type KeyQueryResponse struct {
+	DeviceKeys      map[matrix.UserID]map[matrix.DeviceID]DeviceKeys `json:"device_keys"`
+	MasterKeys      map[matrix.UserID]MasterKeys                     `json:"master_keys"`
+	SelfSigningKeys map[matrix.UserID]SelfSigningKeys                `json:"self_signing_keys"`
+	UserSigningKeys map[matrix.UserID]UserSigningKeys                `json:"user_signing_keys"`
+	// TODO: failures
+}
+
+// DeviceKeys contains information on a queried device.
+type DeviceKeys struct {
+	Algorithms []Algorithm                `json:"algorithms"`
+	DeviceID   matrix.DeviceID            `json:"device_id"`
+	Keys       map[DeviceAlgorithmKey]Key `json:"keys"`
+	Signatures UserSignatures             `json:"signatures"`
+	UserID     matrix.UserID              `json:"user_id"`
+	Unsigned   json.RawMessage            `json:"unsigned,omitempty"` // not in KeyUpload
+}
+
+// MasterKeys contains information on the master cross-signing keys.
+type MasterKeys struct {
+	Keys   map[string]string `json:"keys"`
+	Usage  []string          `json:"usage"` // []string{"master"}
+	UserID matrix.UserID     `json:"user_id"`
+}
+
+// SelfSigningKeys contains information on the self-signing keys.
+type SelfSigningKeys struct {
+	Keys       map[string]string `json:"keys"`
+	Signatures UserSignatures    `json:"signatures"`
+	Usage      []string          `json:"usage"`
+	UserID     matrix.UserID     `json:"user_id"`
+}
+
+// UserSigningKeys contains information on the user-signing key of the user making the request, if
+// they queried their own device information
+type UserSigningKeys struct {
+	Keys       map[string]string `json:"keys"`
+	Signatures UserSignatures    `json:"signatures"`
+	Usage      []string          `json:"usage"`
+	UserID     matrix.UserID     `json:"user_id"`
+}
+
+// KeyQuery returns the current devices and identity keys for the given users. The timeout has an
+// accuracy of 1ms.
+//
+// Parameters:
+//
+//    - deviceKeys: required, the keys to be downloaded. A map from user ID, to a list of device
+//      IDs, or to an empty list to indicate all devices for the corresponding user.
+//    - timeout: the time to wait when downloading keys from remote servers. 10 seconds is the
+//      recommended default.
+//    - token: if the client is fetching keys as a result of a device update received in a sync
+//      request, this should be the ‘since’ token of that sync request, or any later sync token.
+//      This allows the server to ensure its response contains the keys advertised by the
+//      notification in that sync.
+//
+func (c *Client) KeyQuery(deviceKeys map[matrix.UserID][]matrix.DeviceID, timeout time.Duration, token string) (*KeyQueryResponse, error) {
+	req := struct {
+		DeviceKeys map[matrix.UserID][]matrix.DeviceID `json:"device_keys"`
+		Timeout    int                                 `json:"timeout,omitempty"`
+		Token      string                              `json:"token,omitempty"`
+	}{
+		DeviceKeys: deviceKeys,
+		Timeout:    int(timeout / time.Millisecond),
+		Token:      token,
+	}
+
+	var resp KeyQueryResponse
+
+	err := c.Request(
+		"GET", EndpointKeysQuery, &resp,
+		httputil.WithToken(),
+		httputil.WithJSONBody(req),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// KeyUpload publishes end-to-end encryption keys for the device. It returns the new count of
+// one-time keys for the device given in deviceKeys.
+//
+// Parameters:
+//
+//    - deviceKeys: identity keys for the device. May be absent if no new identity keys are
+//      required.
+//    - oneTimeKeys: one-time public keys for “pre-key” messages.
+//
+func (c *Client) KeyUpload(deviceKeys DeviceKeys, oneTimeKeys OneTimeKeys) (count map[Algorithm]int, err error) {
+	req := struct {
+		DeviceKeys  DeviceKeys  `json:"device_keys"`
+		OneTimeKeys OneTimeKeys `json:"one_time_keys"`
+	}{
+		DeviceKeys:  deviceKeys,
+		OneTimeKeys: oneTimeKeys,
+	}
+
+	var resp struct {
+		OneTimeKeyCounts map[Algorithm]int `json:"one_time_key_counts"`
+	}
+
+	err = c.Request(
+		"GET", EndpointKeysUpload, &resp,
+		httputil.WithToken(),
+		httputil.WithJSONBody(req),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.OneTimeKeyCounts, nil
+}

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -1,0 +1,73 @@
+// Package encrypt provides end-to-end encryption support for the Matrix API.
+package encrypt
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/chanbakjsd/gotrix/api"
+	"github.com/chanbakjsd/gotrix/matrix"
+)
+
+// SignatureAlgorithm is the type that describes the names of signature algorithms.
+type SignatureAlgorithm string
+
+const (
+	Ed25519    SignatureAlgorithm = "ed25519"
+	Curve25519 SignatureAlgorithm = "curve25519"
+)
+
+// SignedAlgorithm returns a signed variant of the signature algorithm. Calling this method multiple
+// times will not repeat the same signed prefix.
+func (a SignatureAlgorithm) SignedAlgorithm() SignatureAlgorithm {
+	if !strings.HasPrefix(string(a), "signed_") {
+		return "signed_" + a
+	}
+	return a
+}
+
+// Signature describes a digital cryptography signature of unknown algorithm.
+type Signature string
+
+// SyncResponse contains the extended parts of api.SyncResponse, holding encrypt-specific fields.
+// Use ParseSyncResponse to extract these fields.
+//
+// Quoting from the documentation:
+//
+// This module adds an optional device_lists property to the /sync response, as specified below. The
+// server need only populate this property for an incremental /sync (i.e., one where the since
+// parameter was specified). The client is expected to use /keys/query or /keys/changes for the
+// equivalent functionality after an initial sync, as documented in Tracking the device list for a
+// user.
+type SyncResponse struct {
+	// DeviceLists is the information on e2e device updates. Note: only present on an incremental
+	// sync.
+	DeviceLists struct {
+		// Changed is the list of users who have updated their device identity or cross-signing
+		// keys, or who now share an encrypted room with the client since the previous sync
+		// response.
+		Changed []matrix.UserID `json:"changed"`
+		// Left is the list of users with whom we do not share any encrypted rooms anymore since the
+		// previous sync response.
+		Left []matrix.UserID `json:"left"`
+	} `json:"device_lists,omitempty"`
+	// DeviceOneTimeKeysCount is the number of unclaimed one-time keys currently held on the server
+	// for this device.
+	DeviceOneTimeKeysCount map[Algorithm]int `json:"device_one_time_keys_count,omitempty"`
+}
+
+// ParseSyncResponse parses the encrypt.SyncResponse from the given API SyncResponse.
+func ParseSyncResponse(resp *api.SyncResponse) (*SyncResponse, error) {
+	if resp.Raw() == nil {
+		return nil, errors.New("SyncResponse missing raw JSON")
+	}
+
+	var encResp SyncResponse
+
+	if err := json.Unmarshal(resp.Raw(), &encResp); err != nil {
+		return nil, err
+	}
+
+	return &encResp, nil
+}

--- a/encrypt/endpoints.go
+++ b/encrypt/endpoints.go
@@ -1,0 +1,11 @@
+package encrypt
+
+import "github.com/chanbakjsd/gotrix/api"
+
+var (
+	EndpointKeys        = api.EndpointBase + "/keys"
+	EndpointKeysChanges = EndpointKeys + "/changes"
+	EndpointKeysClaim   = EndpointKeys + "/claim"
+	EndpointKeysQuery   = EndpointKeys + "/query"
+	EndpointKeysUpload  = EndpointKeys + "/upload"
+)

--- a/encrypt/event.go
+++ b/encrypt/event.go
@@ -1,0 +1,165 @@
+package encrypt
+
+import (
+	"encoding/json"
+
+	"github.com/chanbakjsd/gotrix/event"
+	"github.com/chanbakjsd/gotrix/matrix"
+)
+
+// Actual Matrix event
+
+// List of actual Matrix events that is related to end-to-end encryption.
+const (
+	TypeRoomEncryption   event.Type = "m.room.encryption"
+	TypeRoomEncrypted    event.Type = "m.room.encrypted"
+	TypeRoomKey          event.Type = "m.room_key"
+	TypeRoomKeyRequest   event.Type = "m.room_key_request"
+	TypeForwardedRoomKey event.Type = "m.forwarded_room_key"
+	TypeDummy            event.Type = "m.dummy"
+	TypeRoomKeyWithheld  event.Type = "m.room_key.withheld"
+)
+
+var (
+	_ event.StateEvent = &RoomEncryptionEvent{}
+	_ event.RoomEvent  = &RoomEncryptedEvent{}
+	_ event.Event      = &RoomKeyEvent{}
+	_ event.Event      = &RoomKeyRequestEvent{}
+	_ event.Event      = &ForwardedRoomKeyEvent{}
+	_ event.Event      = &DummyEvent{}
+	_ event.Event      = &RoomKeyWithheldEvent{}
+)
+
+// RoomEncryptionEvent is a state event that defines how messages in a room
+// should be encrypted.
+type RoomEncryptionEvent struct {
+	event.StateEventInfo `json:"-"`
+
+	Algorithm Algorithm `json:"algorithm"`
+
+	// How often to rotate keys in milliseconds.
+	RotationTime int `json:"rotation_period_ms"`
+	// How often to rotate keys based on messages sent.
+	RotationMessage int `json:"rotation_period_msgs"`
+}
+
+// Algorithm is the algorithm used for encryption.
+type Algorithm string
+
+// List of algorithms specified in the specification.
+const (
+	AlgorithmOlm    Algorithm = "m.olm.v1.curve25519-aes-sha2"
+	AlgorithmMegOlm Algorithm = "m.megolm.v1.aes-sha2"
+)
+
+// RoomEncryptedEvent is an event that may be a room event or a send-to-device
+// event. It contains encrypted data which should be decrypted and processed.
+type RoomEncryptedEvent struct {
+	event.RoomEventInfo `json:"-"`
+
+	Algorithm  Algorithm       `json:"algorithm"`
+	Ciphertext json.RawMessage `json:"ciphertext"`
+	DeviceID   matrix.DeviceID `json:"device_id,omitempty"`
+	SenderKey  Curve25519Key   `json:"sender_key"`
+	SessionID  SessionID       `json:"session_id,omitempty"`
+}
+
+// RoomKeyEvent is an event used to send room keys, it is typically stored
+// in a RoomEncryptedEvent.
+type RoomKeyEvent struct {
+	event.EventInfo `json:"-"`
+
+	Algorithm  Algorithm     `json:"algorithm"`
+	RoomID     matrix.RoomID `json:"room_id"`
+	SessionID  SessionID     `json:"session_id"`
+	SessionKey Key           `json:"session_key"`
+}
+
+// RoomKeyRequestEvent is an event used to request room keys, it is typically
+// sent as an un-encrypted send-to-device event.
+type RoomKeyRequestEvent struct {
+	event.EventInfo `json:"-"`
+
+	Action           RoomKeyRequestAction `json:"action"`
+	Body             *RoomKeyRequestInfo  `json:"body,omitempty"`
+	RequestID        string               `json:"request_id"`
+	RequestingDevice matrix.DeviceID      `json:"requesting_device_id"`
+}
+
+// RoomKeyRequestAction is the action the RoomKeyRequestEvent is sent for.
+type RoomKeyRequestAction string
+
+// Different types of RoomKeyRequestAction.
+const (
+	RoomKeyRequestRequest RoomKeyRequestAction = "request"
+	RoomKeyRequestCancel  RoomKeyRequestAction = "request_cancellation"
+)
+
+// RoomKeyRequestInfo is the info of the key being requested.
+type RoomKeyRequestInfo struct {
+	Algorithm Algorithm     `json:"algorithm"`
+	RoomID    matrix.RoomID `json:"room_id"`
+	SenderKey Curve25519Key `json:"session_key"`
+	SessionID SessionID     `json:"session_id"`
+}
+
+// ForwardedRoomKeyEvent is used to forward keys for end-to-end encryption.
+// Typically it is encrypted as a RoomEncryptedEvent, then sent as a to-device
+// event.
+type ForwardedRoomKeyEvent struct {
+	event.EventInfo `json:"-"`
+
+	Algorithm Algorithm `json:"algorithm"`
+	// Chain of keys this room key was forwarded from.
+	ForwardChain     []Curve25519Key `json:"forwarding_curve25519_key_chain"`
+	RoomID           matrix.RoomID   `json:"room_id"`
+	SenderClaimedKey Ed25519Key      `json:"sender_claimed_ed25519_key"`
+	SenderKey        Curve25519Key   `json:"sender_key"`
+	SessionID        SessionID       `json:"session_id"`
+	SessionKey       Curve25519Key   `json:"session_key"`
+	// Fields of the withheld event, but not the event itself.
+	Withheld *RoomKeyWithheldEvent `json:"withheld,omitempty"`
+}
+
+// RoomKeyWithheldEvent is an event to notify that room keys have been
+// withheld. Algorithm, code and sender key are always present in the event and
+// one of room ID or session ID is present in the event depending on the
+// RoomKeyWithheldReason.
+type RoomKeyWithheldEvent struct {
+	event.EventInfo `json:"-"`
+
+	Algorithm Algorithm             `json:"algorithm,omitempty"`
+	Code      RoomKeyWithheldReason `json:"code"`
+	// Human-readable version of Code.
+	Reason    string        `json:"reason,omitempty"`
+	RoomID    matrix.RoomID `json:"room_id,omitempty"`
+	SessionID SessionID     `json:"session_id,omitempty"`
+	SenderKey Curve25519Key `json:"sender_key,omitempty"`
+}
+
+// RoomKeyWithheldReason is the reason the room key is withheld instead of sent.
+type RoomKeyWithheldReason string
+
+const (
+	// WithheldReasonBlacklist withholds the room keys because the device
+	// requesting it was blacklisted.
+	WithheldReasonBlacklist RoomKeyWithheldReason = "m.blacklisted"
+	// WithheldReasonUnverified withholds the room keys because the device
+	// requesting it has not been verified yet.
+	WithheldReasonUnverified RoomKeyWithheldReason = "m.unverified"
+	// WithheldReasonUnauthorized withholds the room keys because the device
+	// requesting it does not have permission to do so such as the user not
+	// being in the room.
+	WithheldReasonUnauthorized RoomKeyWithheldReason = "m.unauthorised"
+	// WithheldReasonUnavailable withholds the room keys because the device
+	// does not have the requested room keys.
+	WithheldReasonUnavailable RoomKeyWithheldReason = "m.unavailable"
+	// WithheldReasonOlmFailure withholds the room keys because an Olm session
+	// cannot be established.
+	WithheldReasonOlmFailure RoomKeyWithheldReason = "m.no_olm"
+)
+
+// DummyEvent is a dummy event typically used to initiate renegotiation of keys.
+type DummyEvent struct {
+	event.EventInfo `json:"-"`
+}

--- a/encrypt/event_parse.go
+++ b/encrypt/event_parse.go
@@ -1,0 +1,80 @@
+package encrypt
+
+import (
+	"encoding/json"
+
+	"github.com/chanbakjsd/gotrix/event"
+)
+
+func init() {
+	event.RegisterDefault(TypeRoomEncryption, parseRoomEncryption)
+	event.RegisterDefault(TypeRoomEncrypted, parseRoomEncrypted)
+	event.RegisterDefault(TypeRoomKey, parseRoomKey)
+	event.RegisterDefault(TypeRoomKeyRequest, parseRoomKeyRequest)
+	event.RegisterDefault(TypeForwardedRoomKey, parseForwardRoomKey)
+	event.RegisterDefault(TypeDummy, parseDummy)
+	event.RegisterDefault(TypeRoomKeyWithheld, parseRoomKeyWithheld)
+}
+
+func parseRoomEncryption(content json.RawMessage) (event.Event, error) {
+	var v RoomEncryptionEvent
+	err := json.Unmarshal(content, &v)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func parseRoomEncrypted(content json.RawMessage) (event.Event, error) {
+	var v RoomEncryptedEvent
+	err := json.Unmarshal(content, &v)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func parseRoomKey(content json.RawMessage) (event.Event, error) {
+	var v RoomKeyEvent
+	err := json.Unmarshal(content, &v)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func parseRoomKeyRequest(content json.RawMessage) (event.Event, error) {
+	var v RoomKeyRequestEvent
+	err := json.Unmarshal(content, &v)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func parseForwardRoomKey(content json.RawMessage) (event.Event, error) {
+	var v ForwardedRoomKeyEvent
+	err := json.Unmarshal(content, &v)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func parseDummy(content json.RawMessage) (event.Event, error) {
+	var v DummyEvent
+	err := json.Unmarshal(content, &v)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func parseRoomKeyWithheld(content json.RawMessage) (event.Event, error) {
+	var v RoomKeyWithheldEvent
+	err := json.Unmarshal(content, &v)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}

--- a/encrypt/file.go
+++ b/encrypt/file.go
@@ -1,16 +1,3 @@
 package encrypt
 
-import (
-	"github.com/chanbakjsd/gotrix/matrix"
-)
-
-// File represents an encrypted file.
-type File struct {
-	URL        matrix.URL        `json:"url"`
-	Key        JSONWebKey        `json:"key"`
-	InitVector string            `json:"iv"`
-	Hashes     map[string]string `json:"hashes"`
-	Version    string            `json:"v"`
-}
-
 // TODO Add helper functions for encryption/decryption.

--- a/encrypt/json/LICENSE
+++ b/encrypt/json/LICENSE
@@ -1,0 +1,178 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+

--- a/encrypt/json/README.md
+++ b/encrypt/json/README.md
@@ -1,0 +1,2 @@
+This directory consists of code lifted from gomatrixserverlib's [json.go](https://github.com/matrix-org/gomatrixserverlib/blob/124228cb95480ceb086d9dd4c1b4e48490c83727/json.go).
+The code modified with minor code quality tweaks can be found in `compact.go` and `sort.go` and is subjected to the original Apache 2.0 license.

--- a/encrypt/json/compact.go
+++ b/encrypt/json/compact.go
@@ -1,0 +1,139 @@
+/* Copyright 2016-2017 Vector Creations Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package json
+
+import (
+	"encoding/binary"
+	"unicode/utf8"
+)
+
+// compact removes all whitespace and transforms Unicode escapes to the rune itself.
+func compact(input []byte) []byte {
+	output := make([]byte, 0, len(input))
+
+	var i int
+	for i < len(input) {
+		c := input[i]
+		i++
+		// The valid whitespace characters are all less than or equal to SPACE 0x20.
+		// The valid non-white characters are all greater than SPACE 0x20.
+		// So we can check for whitespace by comparing against SPACE 0x20.
+		if c <= ' ' {
+			// Skip over whitespace.
+			continue
+		}
+		// Add the non-whitespace character to the output.
+		output = append(output, c)
+		if c == '"' {
+			// We are inside a string.
+			for i < len(input) {
+				c = input[i]
+				i++
+				// Check if this is an escape sequence.
+				if c == '\\' {
+					escape := input[i]
+					i++
+					if escape == 'u' {
+						// If this is a unicode escape then we need to handle it specially
+						output, i = compactUnicodeEscape(input, output, i)
+					} else if escape == '/' {
+						// JSON does not require escaping '/', but allows encoders to escape it as a special case.
+						// Since the escape isn't required we remove it.
+						output = append(output, escape)
+					} else {
+						// All other permitted escapes are single charater escapes that are already in their shortest form.
+						output = append(output, '\\', escape)
+					}
+				} else {
+					output = append(output, c)
+				}
+				if c == '"' {
+					break
+				}
+			}
+		}
+	}
+	return output
+}
+
+// compactUnicodeEscape unpacks a 4 byte unicode escape starting at index.
+// If the escape is a surrogate pair then decode the 6 byte \uXXXX escape
+// that follows. Returns the output slice and a new input index.
+func compactUnicodeEscape(input, output []byte, index int) ([]byte, int) {
+	const (
+		ESCAPES = "uuuuuuuubtnufruuuuuuuuuuuuuuuuuu"
+		HEX     = "0123456789ABCDEF"
+	)
+	// If there aren't enough bytes to decode the hex escape then return.
+	if len(input)-index < 4 {
+		return output, len(input)
+	}
+	// Decode the 4 hex digits.
+	c := readHexDigits(input[index:])
+	index += 4
+	if c < ' ' {
+		// If the character is less than SPACE 0x20 then it will need escaping.
+		escape := ESCAPES[c]
+		output = append(output, '\\', escape)
+		if escape == 'u' {
+			output = append(output, '0', '0', byte('0'+(c>>4)), HEX[c&0xF])
+		}
+	} else if c == '\\' || c == '"' {
+		// Otherwise the character only needs escaping if it is a QUOTE '"' or BACKSLASH '\\'.
+		output = append(output, '\\', byte(c))
+	} else if c < 0xD800 || c >= 0xE000 {
+		// If the character isn't a surrogate pair then encoded it directly as UTF-8.
+		var buffer [4]byte
+		n := utf8.EncodeRune(buffer[:], rune(c))
+		output = append(output, buffer[:n]...)
+	} else {
+		// Otherwise the escaped character was the first part of a UTF-16 style surrogate pair.
+		// The next 6 bytes MUST be a '\uXXXX'.
+		// If there aren't enough bytes to decode the hex escape then return.
+		if len(input)-index < 6 {
+			return output, len(input)
+		}
+		// Decode the 4 hex digits from the '\uXXXX'.
+		surrogate := readHexDigits(input[index+2:])
+		index += 6
+		// Reconstruct the UCS4 codepoint from the surrogates.
+		codepoint := 0x10000 + (((c & 0x3FF) << 10) | (surrogate & 0x3FF))
+		// Encode the charater as UTF-8.
+		var buffer [4]byte
+		n := utf8.EncodeRune(buffer[:], rune(codepoint))
+		output = append(output, buffer[:n]...)
+	}
+	return output, index
+}
+
+// Read 4 hex digits from the input slice.
+// Taken from https://github.com/NegativeMjark/indolentjson-rust/blob/8b959791fe2656a88f189c5d60d153be05fe3deb/src/readhex.rs#L21
+func readHexDigits(input []byte) uint32 {
+	hex := binary.BigEndian.Uint32(input)
+	// subtract '0'
+	hex -= 0x30303030
+	// strip the higher bits, maps 'a' => 'A'
+	hex &= 0x1F1F1F1F
+	mask := hex & 0x10101010
+	// subtract 'A' - 10 - '9' - 9 = 7 from the letters.
+	hex -= mask >> 1
+	hex += mask >> 4
+	// collect the nibbles
+	hex |= hex >> 4
+	hex &= 0xFF00FF
+	hex |= hex >> 8
+	return hex & 0xFFFF
+}

--- a/encrypt/json/json.go
+++ b/encrypt/json/json.go
@@ -1,0 +1,19 @@
+package json
+
+import (
+	"encoding/json"
+)
+
+// CanonicalMarshal marshals the provided input and returns the canonicalized JSON.
+func CanonicalMarshal(input interface{}) ([]byte, error) {
+	b, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+	return Canonical(b), nil
+}
+
+// Canonical assumes that the JSON is valid and canonicalizes the JSON.
+func Canonical(input []byte) []byte {
+	return sortJSON(compact(input))
+}

--- a/encrypt/json/json_test.go
+++ b/encrypt/json/json_test.go
@@ -1,0 +1,76 @@
+package json
+
+import "testing"
+
+func TestSpecExamples(t *testing.T) {
+	for _, v := range testCases {
+		got := string(Canonical([]byte(v.Original)))
+
+		if got != v.Canonical {
+			t.Errorf("spec example mismatch:\n"+
+				"Got:      %s\n"+
+				"Expected: %s",
+				got, v.Canonical,
+			)
+		}
+	}
+}
+
+func TestUnsignedAndSignaturesDropped(t *testing.T) {
+	result := string(Canonical([]byte(`{"unsigned":{"a":"b"}, "signatures":{"c":"d"}}`)))
+	if result != "{}" {
+		t.Errorf("Unsigned/Signature drop mismatch:\n"+
+			"Got:      %s\n"+
+			"Expected: {}",
+			result,
+		)
+	}
+}
+
+var testCases = []struct {
+	Original  string
+	Canonical string
+}{
+	{`{}`, `{}`},
+	{`{"b":"2","a":"1"}`, `{"a":"1","b":"2"}`},
+	{`{
+			"one": 1,
+			"two": "Two"
+		}`, `{"one":1,"two":"Two"}`},
+	{`{
+			"b": "2",
+			"a": "1"
+		}`, `{"a":"1","b":"2"}`},
+	{`{
+		"auth": {
+			"success": true,
+			"mxid": "@john.doe:example.com",
+			"profile": {
+				"display_name": "John Doe",
+				"three_pids": [
+					{
+						"medium": "email",
+						"address": "john.doe@example.org"
+					},
+					{
+						"medium": "msisdn",
+						"address": "123456789"
+					}
+				]
+			}
+		}
+	}`, `{"auth":{"mxid":"@john.doe:example.com","profile":{"display_name":"John Doe","three_pids":[{"address":"john.doe@example.org","medium":"email"},{"address":"123456789","medium":"msisdn"}]},"success":true}}`},
+	{`{
+		"a": "日本語"
+	}`, `{"a":"日本語"}`},
+	{`{
+		"本": 2,
+		"日": 1
+	}`, `{"日":1,"本":2}`},
+	{`{
+		"a": "\u65E5"
+	}`, `{"a":"日"}`},
+	{`{
+		"a": null
+	}`, `{"a":null}`},
+}

--- a/encrypt/json/sort.go
+++ b/encrypt/json/sort.go
@@ -1,0 +1,127 @@
+package json
+
+import (
+	"sort"
+
+	"github.com/tidwall/gjson"
+)
+
+func sortJSON(input []byte) []byte {
+	output := make([]byte, 0, len(input))
+	result := gjson.ParseBytes(input)
+
+	rawJSON := rawJSONFromResult(result, input)
+	return sortJSONValue(result, rawJSON, output)
+}
+
+// rawJSONFromResult extracts the raw JSON bytes pointed to by result.
+// input must be the json bytes that were used to generate result
+func rawJSONFromResult(result gjson.Result, input []byte) []byte {
+	// This is lifted from gjson README. Basically, result.Raw is a copy of
+	// the bytes we want, but its more efficient to take a slice.
+	// If Index is 0 then for some reason we can't extract it from the original
+	// JSON bytes.
+	if result.Index > 0 {
+		return input[result.Index : result.Index+len(result.Raw)]
+	}
+	return []byte(result.Raw)
+}
+
+// sortJSONValue takes a gjson.Result and sorts it. inputJSON must be the
+// raw JSON bytes that gjson.Result points to.
+func sortJSONValue(input gjson.Result, inputJSON, output []byte) []byte {
+	if input.IsArray() {
+		return sortJSONArray(input, inputJSON, output)
+	}
+
+	if input.IsObject() {
+		return sortJSONObject(input, inputJSON, output)
+	}
+
+	// If its neither an object nor an array then there is no sub structure
+	// to sort, so just append the raw bytes.
+	return append(output, inputJSON...)
+}
+
+// sortJSONArray takes a gjson.Result and sorts it, assuming its an array.
+// inputJSON must be the raw JSON bytes that gjson.Result points to.
+func sortJSONArray(input gjson.Result, inputJSON, output []byte) []byte {
+	sep := byte('[')
+
+	// Iterate over each value in the array and sort it.
+	input.ForEach(func(_, value gjson.Result) bool {
+		output = append(output, sep)
+		sep = ','
+
+		rawJSON := rawJSONFromResult(value, inputJSON)
+		output = sortJSONValue(value, rawJSON, output)
+
+		return true // keep iterating
+	})
+
+	if sep == '[' {
+		// If sep is still '[' then the array was empty and we never wrote the
+		// initial '[', so we write it now along with the closing ']'.
+		output = append(output, '[', ']')
+	} else {
+		// Otherwise we end the array by writing a single ']'
+		output = append(output, ']')
+	}
+	return output
+}
+
+// sortJSONObject takes a gjson.Result and sorts it, assuming its an object.
+// inputJSON must be the raw JSON bytes that gjson.Result points to.
+func sortJSONObject(input gjson.Result, inputJSON, output []byte) []byte {
+	type entry struct {
+		key    string // The parsed key string
+		rawKey []byte // The raw, unparsed key JSON string
+		value  gjson.Result
+	}
+
+	var entries []entry
+
+	// Iterate over each key/value pair and add it to a slice
+	// that we can sort
+	input.ForEach(func(key, value gjson.Result) bool {
+		if key.String() == "unsigned" || key.String() == "signatures" {
+			// Don't include unsigned/signatures.
+			return true
+		}
+		entries = append(entries, entry{
+			key:    key.String(),
+			rawKey: rawJSONFromResult(key, inputJSON),
+			value:  value,
+		})
+		return true // keep iterating
+	})
+
+	// Sort the slice based on the *parsed* key
+	sort.Slice(entries, func(a, b int) bool {
+		return entries[a].key < entries[b].key
+	})
+
+	sep := byte('{')
+
+	for _, entry := range entries {
+		output = append(output, sep)
+		sep = ','
+
+		// Append the raw unparsed JSON key, *not* the parsed key
+		output = append(output, entry.rawKey...)
+		output = append(output, ':')
+
+		rawJSON := rawJSONFromResult(entry.value, inputJSON)
+
+		output = sortJSONValue(entry.value, rawJSON, output)
+	}
+	if sep == '{' {
+		// If sep is still '{' then the object was empty and we never wrote the
+		// initial '{', so we write it now along with the closing '}'.
+		output = append(output, '{', '}')
+	} else {
+		// Otherwise we end the object by writing a single '}'
+		output = append(output, '}')
+	}
+	return output
+}

--- a/encrypt/key.go
+++ b/encrypt/key.go
@@ -1,9 +1,2 @@
 package encrypt
 
-// JSONWebKey represents a JSON web key.
-type JSONWebKey struct {
-	KeyType       string   `json:"kty"`     // Type of key. Must be "oct".
-	KeyOperations []string `json:"key_ops"` // Key operations.
-	Algorithm     string   `json:"alg"`     // URLSafe unpadded base64 key.
-	Extractable   bool     `json:"ext"`     // Must be true.
-}

--- a/encrypt/key.go
+++ b/encrypt/key.go
@@ -1,10 +1,10 @@
 package encrypt
 
 // Curve25519Key is a key to be used for curve25519.
-type Curve25519Key string
+type Curve25519Key Key
 
 // Ed25519Key is a key to be used for ed25519.
-type Ed25519Key string
+type Ed25519Key Key
 
-// Key is a key of unknown type.
+// Key is a key of unknown algorithm.
 type Key string

--- a/encrypt/key.go
+++ b/encrypt/key.go
@@ -1,2 +1,10 @@
 package encrypt
 
+// Curve25519Key is a key to be used for curve25519.
+type Curve25519Key string
+
+// Ed25519Key is a key to be used for ed25519.
+type Ed25519Key string
+
+// Key is a key of unknown type.
+type Key string

--- a/encrypt/olm/account.go
+++ b/encrypt/olm/account.go
@@ -1,0 +1,178 @@
+package olm
+
+// #include <stdlib.h>
+// #include "olm/olm.h"
+import "C"
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// Account is an account that is associated with a device owned by a user.
+type Account struct {
+	acc *C.OlmAccount
+}
+
+// NewRawAccount creates a new uninitialized account.
+func NewRawAccount() *Account {
+	mem := C.malloc(accountSize)
+	cAcc := C.olm_account(mem)
+	acc := Account{
+		acc: cAcc,
+	}
+	runtime.SetFinalizer(&acc, func(_ *Account) {
+		C.free(mem)
+	})
+
+	return &acc
+}
+
+// NewAccount creates a new account initialized by random bytes from crypto/rand.
+func NewAccount() (*Account, error) {
+	a := NewRawAccount()
+	randomLen := C.olm_create_account_random_length(a.acc)
+	randomBytes := make([]byte, randomLen)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return nil, fmt.Errorf("olm: error fetching random bytes: %w", err)
+	}
+
+	cBytes := C.CBytes(randomBytes)
+	defer C.free(cBytes)
+
+	ret := C.olm_create_account(a.acc, cBytes, randomLen)
+	if ret == errValue {
+		return nil, a.LastError()
+	}
+	return a, nil
+}
+
+// NewAccountFromPickle creates an account from the provided key and pickle.
+func NewAccountFromPickle(key, pickle string) (*Account, error) {
+	a := NewRawAccount()
+	cKey := unsafe.Pointer(C.CString(key))
+	cPickle := unsafe.Pointer(C.CString(pickle))
+	defer C.free(cKey)
+	defer C.free(cPickle)
+
+	ret := C.olm_unpickle_account(a.acc, cKey, C.size_t(len(key)), cPickle, C.size_t(len(pickle)))
+	if ret == errValue {
+		return nil, a.LastError()
+	}
+	return a, nil
+}
+
+// LastError returns the last error Account returned.
+func (a *Account) LastError() error {
+	str := C.GoString(C.olm_account_last_error(a.acc))
+	if str == noErr {
+		return nil
+	}
+	return errors.New("olm: account error: " + str)
+}
+
+// Clear clears the backing memory of Account.
+func (a *Account) Clear() error {
+	ret := C.olm_clear_account(a.acc)
+	if ret == errValue {
+		return a.LastError()
+	}
+	return nil
+}
+
+// Pickle stores the account as a base64 string encrypted by key.
+func (a *Account) Pickle(key string) (string, error) {
+	length := C.olm_pickle_account_length(a.acc)
+	pickle := C.malloc(length)
+	cKey := C.CString(key)
+	defer C.free(pickle)
+	defer C.free(unsafe.Pointer(cKey))
+
+	ret := C.olm_pickle_account(a.acc, unsafe.Pointer(cKey), C.size_t(len(key)), pickle, length)
+	if ret == errValue {
+		return "", a.LastError()
+	}
+	return C.GoStringN((*C.char)(pickle), C.int(ret)), nil
+}
+
+// IdentityKeys returns the public part of the identity keys for an account.
+func (a *Account) IdentityKeys() (string, error) {
+	length := C.olm_account_identity_keys_length(a.acc)
+	idKeys := C.malloc(length)
+	defer C.free(idKeys)
+
+	ret := C.olm_account_identity_keys(a.acc, idKeys, length)
+	if ret == errValue {
+		return "", a.LastError()
+	}
+	return C.GoString((*C.char)(idKeys)), nil
+}
+
+// Sign signs the provided message with the ED25519 key of the account.
+func (a *Account) Sign(message string) (string, error) {
+	length := C.olm_account_signature_length(a.acc)
+	cMsg := unsafe.Pointer(C.CString(message))
+	signature := C.malloc(length)
+	defer C.free(cMsg)
+	defer C.free(signature)
+
+	ret := C.olm_account_sign(a.acc, cMsg, C.size_t(len(message)), signature, length)
+	if ret == errValue {
+		return "", a.LastError()
+	}
+	return C.GoString((*C.char)(signature)), nil
+}
+
+// OneTimeKeys generates a new set of one time keys and returns unpublished one time keys
+// in the form of a JSON-formatted object containing the 'curve25519' property.
+//
+// The 'curve25519' property contains an object that maps key ID to base64 encoded Curve25519 keys.
+func (a *Account) OneTimeKeys() (string, error) {
+	count := C.olm_account_max_number_of_one_time_keys(a.acc)
+	randomLen := C.olm_account_generate_one_time_keys_random_length(a.acc, count)
+	randomBytes := make([]byte, randomLen)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return "", fmt.Errorf("olm: error fetching random bytes: %w", err)
+	}
+
+	cBytes := C.CBytes(randomBytes)
+	defer C.free(cBytes)
+
+	ret := C.olm_account_generate_one_time_keys(a.acc, count, cBytes, randomLen)
+	if ret == errValue {
+		return "", a.LastError()
+	}
+
+	length := C.olm_account_one_time_keys_length(a.acc)
+	oneTimeKeys := C.malloc(length)
+	defer C.free(oneTimeKeys)
+
+	ret = C.olm_account_one_time_keys(a.acc, oneTimeKeys, length)
+	if ret == errValue {
+		return "", a.LastError()
+	}
+	return C.GoString((*C.char)(oneTimeKeys)), nil
+}
+
+// MarkKeysAsPublished marks the current set of one time keys as published.
+func (a *Account) MarkKeysAsPublished() error {
+	ret := C.olm_account_mark_keys_as_published(a.acc)
+	if ret == errValue {
+		return a.LastError()
+	}
+	return nil
+}
+
+// RemoveOneTimeKeys removes the one-time keys associated with the provided Session.
+func (a *Account) RemoveOneTimeKeys(s *Session) error {
+	ret := C.olm_remove_one_time_keys(a.acc, s.sess)
+	if ret == errValue {
+		return a.LastError()
+	}
+	return nil
+}

--- a/encrypt/olm/olm.go
+++ b/encrypt/olm/olm.go
@@ -1,0 +1,25 @@
+package olm
+
+// #cgo LDFLAGS: -lolm
+// #include <stdlib.h>
+// #include "olm/olm.h"
+import "C"
+
+var (
+	errValue = C.olm_error()
+	noErr    = "SUCCESS"
+)
+
+// Sizes of the structs provided by olm.
+var (
+	accountSize = C.olm_account_size()
+	sessionSize = C.olm_session_size()
+	utilitySize = C.olm_utility_size()
+)
+
+// LibraryVersion returns the version of the cgo library embedded in the form of a major, minor, patch triplet.
+func LibraryVersion() (uint8, uint8, uint8) {
+	var major, minor, patch C.uchar
+	C.olm_get_library_version(&major, &minor, &patch)
+	return uint8(major), uint8(minor), uint8(patch)
+}

--- a/encrypt/olm/session.go
+++ b/encrypt/olm/session.go
@@ -1,0 +1,196 @@
+package olm
+
+// #include <stdlib.h>
+// #include "olm/olm.h"
+import "C"
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// Session is a struct that tracks a group of people that share the same keys with each other.
+type Session struct {
+	sess *C.OlmSession
+}
+
+// NewRawSession creates a new uninitialized session.
+func NewRawSession() *Session {
+	mem := C.malloc(sessionSize)
+	cSess := C.olm_session(mem)
+	s := Session{
+		sess: cSess,
+	}
+	runtime.SetFinalizer(&s, func(_ *Session) {
+		C.free(mem)
+	})
+
+	return &s
+}
+
+// NewOutboundSession generates a new outbound session.
+func NewOutboundSession(a *Account, theirIdentityKey string, theirOneTimeKey string) (*Session, error) {
+	s := NewRawSession()
+	randomLen := C.olm_create_outbound_session_random_length(s.sess)
+	randomBytes := make([]byte, randomLen)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return nil, fmt.Errorf("olm: error fetching random bytes: %w", err)
+	}
+
+	cBytes := C.CBytes(randomBytes)
+	defer C.free(cBytes)
+
+	cIDKey := unsafe.Pointer(C.CString(theirIdentityKey))
+	cOTKey := unsafe.Pointer(C.CString(theirOneTimeKey))
+	defer C.free(cIDKey)
+	defer C.free(cOTKey)
+
+	ret := C.olm_create_outbound_session(
+		s.sess, a.acc, cIDKey, C.size_t(len(theirIdentityKey)), cOTKey, C.size_t(len(theirOneTimeKey)),
+		cBytes, randomLen,
+	)
+	if ret == errValue {
+		return nil, s.LastError()
+	}
+	return s, nil
+}
+
+// NewInboundSession generates a new inbound session from the local Account, the other party's identity key
+// and the message send by the other party.
+func NewInboundSession(a *Account, identityKey string, otkMsg string) (*Session, error) {
+	s := NewRawSession()
+
+	cIDKey := unsafe.Pointer(C.CString(identityKey))
+	cOTKMsg := unsafe.Pointer(C.CString(otkMsg))
+	defer C.free(cIDKey)
+	defer C.free(cOTKMsg)
+
+	ret := C.olm_create_inbound_session_from(
+		s.sess, a.acc, cIDKey, C.size_t(len(identityKey)), cOTKMsg, C.size_t(len(otkMsg)),
+	)
+	if ret == errValue {
+		return nil, s.LastError()
+	}
+	return s, nil
+}
+
+// NewSessionFromPickle creates a session from the provided key and pickle.
+func NewSessionFromPickle(key, pickle string) (*Session, error) {
+	s := NewRawSession()
+	cKey := unsafe.Pointer(C.CString(key))
+	cPickle := unsafe.Pointer(C.CString(pickle))
+	defer C.free(cKey)
+	defer C.free(cPickle)
+
+	ret := C.olm_unpickle_session(s.sess, cKey, C.size_t(len(key)), cPickle, C.size_t(len(pickle)))
+	if ret == errValue {
+		return nil, s.LastError()
+	}
+	return s, nil
+}
+
+// LastError returns the last error Session returned.
+func (s *Session) LastError() error {
+	str := C.GoString(C.olm_session_last_error(s.sess))
+	if str == noErr {
+		return nil
+	}
+	return errors.New("olm: session error: " + str)
+}
+
+// Clear clears the backing memory of Session.
+func (s *Session) Clear() error {
+	ret := C.olm_clear_session(s.sess)
+	if ret == errValue {
+		return s.LastError()
+	}
+	return nil
+}
+
+// ID returns the ID of the session. It will be the same on both ends.
+func (s *Session) ID() (string, error) {
+	length := C.olm_session_id_length(s.sess)
+	id := C.malloc(length)
+	defer C.free(id)
+
+	ret := C.olm_session_id(s.sess, id, length)
+	if ret == errValue {
+		return "", s.LastError()
+	}
+	return C.GoString((*C.char)(id)), nil
+}
+
+// MatchesInbound returns if the provided OTK message is for this inbound session.
+func (s *Session) MatchesInbound(otkMsg string) (bool, error) {
+	cOTKMsg := unsafe.Pointer(C.CString(otkMsg))
+	defer C.free(cOTKMsg)
+
+	ret := C.olm_matches_inbound_session(s.sess, cOTKMsg, C.size_t(len(otkMsg)))
+	if ret == errValue {
+		return false, s.LastError()
+	}
+	return ret == 1, nil
+}
+
+// Pickle stores the session as a base64 string encrypted by key.
+func (s *Session) Pickle(key string) (string, error) {
+	length := C.olm_pickle_session_length(s.sess)
+	pickle := C.malloc(length)
+	cKey := unsafe.Pointer(C.CString(key))
+	defer C.free(pickle)
+	defer C.free(cKey)
+
+	ret := C.olm_pickle_session(s.sess, cKey, C.size_t(len(key)), pickle, length)
+	if ret == errValue {
+		return "", s.LastError()
+	}
+	return C.GoStringN((*C.char)(pickle), C.int(ret)), nil
+}
+
+// Encrypt encrypts the provided plaintext and returns the message type with the encrypted message.
+func (s *Session) Encrypt(plaintext string) (int, string, error) {
+	randomLen := C.olm_encrypt_random_length(s.sess)
+	randomBytes := make([]byte, randomLen)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return 0, "", fmt.Errorf("olm: error fetching random bytes: %w", err)
+	}
+
+	cBytes := C.CBytes(randomBytes)
+	defer C.free(cBytes)
+
+	msgType := C.olm_encrypt_message_type(s.sess)
+	if msgType == errValue {
+		return 0, "", s.LastError()
+	}
+
+	msgLen := C.olm_encrypt_message_length(s.sess, C.size_t(len(plaintext)))
+	cPlaintext := unsafe.Pointer(C.CString(plaintext))
+	cMsg := C.malloc(msgLen)
+
+	ret := C.olm_encrypt(s.sess, cPlaintext, C.size_t(len(plaintext)), cBytes, randomLen, cMsg, msgLen)
+	if ret == errValue {
+		return 0, "", s.LastError()
+	}
+	return int(msgType), C.GoStringN((*C.char)(cMsg), C.int(ret)), nil
+}
+
+// Decrypt decrypts the provided encrypted text.
+func (s *Session) Decrypt(msgType int, encrypted string) (string, error) {
+	cEncrypted := unsafe.Pointer(C.CString(encrypted))
+	defer C.free(cEncrypted)
+
+	plaintextLen := C.olm_decrypt_max_plaintext_length(s.sess, C.size_t(msgType), cEncrypted, C.size_t(len(encrypted)))
+	plaintext := C.malloc(plaintextLen)
+	defer C.free(plaintext)
+
+	ret := C.olm_decrypt(s.sess, C.size_t(msgType), cEncrypted, C.size_t(len(encrypted)), plaintext, plaintextLen)
+	if ret == errValue {
+		return "", s.LastError()
+	}
+	return C.GoStringN((*C.char)(plaintext), C.int(ret)), nil
+}

--- a/encrypt/olm/util.go
+++ b/encrypt/olm/util.go
@@ -1,0 +1,78 @@
+package olm
+
+// #include "olm/olm.h"
+import "C"
+
+import (
+	"errors"
+	"sync"
+	"unsafe"
+)
+
+var util = newUtility()
+
+type utility struct {
+	mu   sync.Mutex
+	util *C.OlmUtility
+}
+
+// newUtility creates a new Utility struct. It does not free as only one instance should be initialized at any point.
+// Use the util global variable instead.
+func newUtility() *utility {
+	mem := C.malloc(utilitySize)
+	return &utility{
+		util: C.olm_utility(mem),
+	}
+}
+
+// LastError returns the last error utility returned.
+func (u *utility) LastError() error {
+	str := C.GoString(C.olm_utility_last_error(u.util))
+	if str == noErr {
+		return nil
+	}
+	return errors.New("olm: utility error: " + str)
+}
+
+// Clear clears the backing memory of utility.
+func (u *utility) Clear() error {
+	ret := C.olm_clear_utility(u.util)
+	if ret == errValue {
+		return u.LastError()
+	}
+	return nil
+}
+
+// SHA256 calculates the base-64 encoded SHA256 hash.
+func SHA256(input string) (string, error) {
+	util.mu.Lock()
+	defer util.mu.Unlock()
+
+	length := C.olm_sha256_length(util.util)
+	output := C.malloc(length)
+	cInput := unsafe.Pointer(C.CString(input))
+
+	ret := C.olm_sha256(util.util, cInput, C.size_t(len(input)), output, length)
+	if ret == errValue {
+		return "", util.LastError()
+	}
+	return C.GoStringN((*C.char)(output), C.int(length)), nil
+}
+
+// VerifyED25519 verifies that the message and signature is associated with key.
+func VerifyED25519(key string, message string, signature string) error {
+	util.mu.Lock()
+	defer util.mu.Unlock()
+
+	cKey := unsafe.Pointer(C.CString(key))
+	cMessage := unsafe.Pointer(C.CString(message))
+	cSignature := unsafe.Pointer(C.CString(signature))
+	ret := C.olm_ed25519_verify(
+		util.util, cKey, C.size_t(len(key)), cMessage, C.size_t(len(message)),
+		cSignature, C.size_t(len(signature)),
+	)
+	if ret == errValue {
+		return util.LastError()
+	}
+	return nil
+}

--- a/encrypt/state.go
+++ b/encrypt/state.go
@@ -1,0 +1,4 @@
+package encrypt
+
+// SessionID is the ID of the current Megolm session.
+type SessionID string

--- a/event/encrypt.go
+++ b/event/encrypt.go
@@ -1,0 +1,20 @@
+package event
+
+import "github.com/chanbakjsd/gotrix/matrix"
+
+// EncryptedFile represents an encrypted file.
+type EncryptedFile struct {
+	URL        matrix.URL        `json:"url"`
+	Key        JSONWebKey        `json:"key"`
+	InitVector string            `json:"iv"`
+	Hashes     map[string]string `json:"hashes"`
+	Version    string            `json:"v"`
+}
+
+// JSONWebKey represents a JSON web key.
+type JSONWebKey struct {
+	KeyType       string   `json:"kty"`     // Type of key. Must be "oct".
+	KeyOperations []string `json:"key_ops"` // Key operations.
+	Algorithm     string   `json:"alg"`     // URLSafe unpadded base64 key.
+	Extractable   bool     `json:"ext"`     // Must be true.
+}

--- a/event/im_message.go
+++ b/event/im_message.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/chanbakjsd/gotrix/encrypt"
 	"github.com/chanbakjsd/gotrix/matrix"
 )
 
@@ -31,7 +30,7 @@ type RoomMessageEvent struct {
 
 	// These fields are present in Image, File, Audio, Video.
 	URL  matrix.URL    `json:"url,omitempty"`  // Present if content is not encrypted.
-	File *encrypt.File `json:"file,omitempty"` // Present if content is encrypted.
+	File EncryptedFile `json:"file,omitempty"` // Present if content is encrypted.
 
 	// This field is present in Image, File, Audio, Video, Location.
 	// The relevant parsing functions should be used.
@@ -78,7 +77,7 @@ type FileInfo struct {
 	MimeType      string        `json:"mimetype,omitempty"`       // MIME type of image.
 	Size          int           `json:"size,omitempty"`           // Size in bytes.
 	ThumbnailURL  matrix.URL    `json:"thumbnail_url,omitempty"`  // Present if thumbnail is un-encrypted.
-	ThumbnailFile encrypt.File  `json:"thumbnail_file,omitempty"` // Present if thumbnail is encrypted.
+	ThumbnailFile EncryptedFile `json:"thumbnail_file,omitempty"` // Present if thumbnail is encrypted.
 	ThumbnailInfo ThumbnailInfo `json:"thumbnail_info,omitempty"`
 }
 
@@ -101,7 +100,7 @@ type AudioInfo struct {
 // LocationInfo stores the info of a location.
 type LocationInfo struct {
 	ThumbnailURL  matrix.URL    `json:"thumbnail_url,omitempty"`  // Present if thumbnail is un-encrypted.
-	ThumbnailFile encrypt.File  `json:"thumbnail_file,omitempty"` // Present if thumbnail is encrypted.
+	ThumbnailFile EncryptedFile `json:"thumbnail_file,omitempty"` // Present if thumbnail is encrypted.
 	ThumbnailInfo ThumbnailInfo `json:"thumbnail_info,omitempty"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/chanbakjsd/gotrix
 
 go 1.16
 
-require github.com/fatih/color v1.10.0
+require (
+	github.com/fatih/color v1.10.0
+	github.com/tidwall/gjson v1.8.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,12 @@ github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/tidwall/gjson v1.8.0 h1:Qt+orfosKn0rbNTZqHYDqBrmm3UDA4KRkv70fDzG+PQ=
+github.com/tidwall/gjson v1.8.0/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
    This commit adds encrypt.Client and wraps the /keys/X endpoints. It also
    adds the needed types and helper methods for those types. Some types
    that are created in this commit will be used outside of the Client as
    well.
    
    This commit also removes some encrypt-specific fields from
    api.SyncResponse in favor of encrypt's own SyncResponse, which the user
    can use by calling encrypt.ParseSyncResponse with the api.SyncResponse.
    This is done to prevent possibly cyclical imports while ensuring that
    the right types are used.
    
    In order to do that, api.SyncResponse now keeps the raw JSON of every
    single field. This not only allows encrypt to do what it's doing, but it
    also allows the user to implement whatever API that extends its /sync.
    It may be a bit too wasteful, but future considerations can be made to
    remove already-parsed fields.