### PR TITLE
Implement endpoint multiversion support

### DIFF
--- a/api/3pid.go
+++ b/api/3pid.go
@@ -21,7 +21,7 @@ type ThirdpartyIdentifier struct {
 func (c *Client) ThreePID() ([]ThirdpartyIdentifier, error) {
 	resp := []ThirdpartyIdentifier{}
 	err := c.Request(
-		"GET", EndpointAccount3PID, &resp,
+		"GET", c.Endpoints.Account3PID(), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -45,13 +45,13 @@ func (c *Client) ThreePIDAdd(clientSecret string, sessionID string) (*UserIntera
 	uiaa.Request = func(auth, to interface{}) error {
 		req.Auth = auth
 		return c.Request(
-			"POST", EndpointAccount3PIDAdd, to,
+			"POST", c.Endpoints.Account3PIDAdd(), to,
 			httputil.WithToken(), httputil.WithJSONBody(req),
 		)
 	}
 	uiaa.RequestThreePID = func(authType string, auth, to interface{}) error {
 		return c.Request(
-			"POST", EndpointAccount3PIDRequestToken(authType), to,
+			"POST", c.Endpoints.Account3PIDRequestToken(authType), to,
 			httputil.WithJSONBody(auth),
 		)
 	}
@@ -73,7 +73,7 @@ type ThreePIDBindArg struct {
 // to the current token.
 func (c *Client) ThreePIDBind(req ThreePIDBindArg) error {
 	err := c.Request(
-		"POST", EndpointAccount3PIDBind, nil,
+		"POST", c.Endpoints.Account3PIDBind(), nil,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {

--- a/api/accountMgmt.go
+++ b/api/accountMgmt.go
@@ -24,7 +24,7 @@ func (c *Client) PasswordChange(newPassword string, logoutDevices bool) (*UserIn
 	uiaa.Request = func(auth, to interface{}) error {
 		req.Auth = auth
 		err := c.Request(
-			"POST", EndpointAccountPassword, to,
+			"POST", c.Endpoints.AccountPassword(), to,
 			httputil.WithToken(), httputil.WithJSONBody(req),
 		)
 		if err != nil {
@@ -34,7 +34,7 @@ func (c *Client) PasswordChange(newPassword string, logoutDevices bool) (*UserIn
 	}
 	uiaa.RequestThreePID = func(authType string, auth, to interface{}) error {
 		return c.Request(
-			"POST", EndpointAccountPasswordRequestToken(authType), nil,
+			"POST", c.Endpoints.AccountPasswordRequestToken(authType), nil,
 			httputil.WithJSONBody(auth),
 		)
 	}
@@ -63,7 +63,7 @@ func (c *Client) DeactivateAccount(idServer string) (InteractiveDeactivate, erro
 	uiaa.Request = func(auth, to interface{}) error {
 		req.Auth = auth
 		err := c.Request(
-			"POST", EndpointAccountDeactivate, to,
+			"POST", c.Endpoints.AccountDeactivate(), to,
 			httputil.WithToken(), httputil.WithJSONBody(req),
 		)
 		if err != nil {

--- a/api/auth.go
+++ b/api/auth.go
@@ -15,7 +15,7 @@ func (c *Client) GetLoginMethods() ([]matrix.LoginMethod, error) {
 		} `json:"flows"`
 	}
 
-	err := c.Request("GET", EndpointLogin, &response)
+	err := c.Request("GET", c.Endpoints.Login(), &response)
 	if err != nil {
 		return nil, fmt.Errorf("error getting login methods: %w", err)
 	}
@@ -52,7 +52,7 @@ func (c *Client) Login(arg LoginArg) error {
 		WellKnown   DiscoveryInfoResponse `json:"well_known"`
 	}
 
-	err := c.Request("POST", EndpointLogin, &resp, httputil.WithJSONBody(arg))
+	err := c.Request("POST", c.Endpoints.Login(), &resp, httputil.WithJSONBody(arg))
 	if err != nil {
 		return fmt.Errorf("error logging in: %w", err)
 	}
@@ -67,7 +67,7 @@ func (c *Client) Login(arg LoginArg) error {
 // Logout clears the AccessToken field in the client and attempts to invalidate the
 // token on the server-side.
 func (c *Client) Logout() error {
-	err := c.Request("POST", EndpointLogout, nil, httputil.WithToken())
+	err := c.Request("POST", c.Endpoints.Logout(), nil, httputil.WithToken())
 	c.AccessToken = ""
 	if err != nil {
 		return fmt.Errorf("error logging out: %w", err)
@@ -78,7 +78,7 @@ func (c *Client) Logout() error {
 // LogoutAll clears the AccessToken field in the client and attempts to invalidate all
 // tokens on the server-side.
 func (c *Client) LogoutAll() error {
-	err := c.Request("POST", EndpointLogoutAll, nil, httputil.WithToken())
+	err := c.Request("POST", c.Endpoints.LogoutAll(), nil, httputil.WithToken())
 	c.AccessToken = ""
 	if err != nil {
 		return fmt.Errorf("error logging out all tokens: %w", err)

--- a/api/client.go
+++ b/api/client.go
@@ -14,6 +14,7 @@ import (
 // For routes expecting user ID, the UserID field is used unless otherwise provided.
 type Client struct {
 	httputil.Client
+	Endpoints      Endpoints
 	IdentityServer string
 	UserID         matrix.UserID
 	DeviceID       matrix.DeviceID
@@ -40,7 +41,7 @@ func (c *Client) Whoami() (matrix.UserID, matrix.DeviceID, error) {
 	}
 
 	err := c.Request(
-		"GET", EndpointAccountWhoami, &resp,
+		"GET", c.Endpoints.AccountWhoami(), &resp,
 		httputil.WithToken(), httputil.WithQuery(map[string]string{
 			"user_id": string(c.UserID),
 		}),
@@ -58,7 +59,7 @@ func (c *Client) ServerCapabilities() (*matrix.Capabilities, error) {
 	}
 
 	err := c.Request(
-		"GET", EndpointCapabilities, &resp,
+		"GET", c.Endpoints.Capabilities(), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {

--- a/api/config.go
+++ b/api/config.go
@@ -13,7 +13,7 @@ import (
 // 'v' is a pointer that is directly passed into json.Unmarshal to unmarshal the content of the config.
 func (c *Client) ClientConfig(configType string, v interface{}) error {
 	err := c.Request(
-		"GET", EndpointAccountDataGlobal(c.UserID, configType), v,
+		"GET", c.Endpoints.AccountDataGlobal(c.UserID, configType), v,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -30,7 +30,7 @@ func (c *Client) ClientConfig(configType string, v interface{}) error {
 // of SyncResponse.
 func (c *Client) ClientConfigSet(configType string, config interface{}) error {
 	err := c.Request(
-		"PUT", EndpointAccountDataGlobal(c.UserID, configType), nil,
+		"PUT", c.Endpoints.AccountDataGlobal(c.UserID, configType), nil,
 		httputil.WithToken(), httputil.WithJSONBody(config),
 	)
 	if err != nil {
@@ -43,7 +43,7 @@ func (c *Client) ClientConfigSet(configType string, config interface{}) error {
 // 'v' is a pointer that is directly passed into json.Unmarshal to unmarshal the content of the config.
 func (c *Client) ClientConfigRoom(roomID matrix.RoomID, configType string, v interface{}) error {
 	err := c.Request(
-		"GET", EndpointAccountDataRoom(c.UserID, roomID, configType), v,
+		"GET", c.Endpoints.AccountDataRoom(c.UserID, roomID, configType), v,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -62,7 +62,7 @@ func (c *Client) ClientConfigRoom(roomID matrix.RoomID, configType string, v int
 func (c *Client) ClientConfigRoomSet(roomID matrix.RoomID, configType string,
 	config interface{}) error {
 	err := c.Request(
-		"PUT", EndpointAccountDataRoom(c.UserID, roomID, configType), nil,
+		"PUT", c.Endpoints.AccountDataRoom(c.UserID, roomID, configType), nil,
 		httputil.WithToken(), httputil.WithJSONBody(config),
 	)
 	if err != nil {

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -7,136 +7,164 @@ import (
 	"github.com/chanbakjsd/gotrix/matrix"
 )
 
-// Version is the Client-Server API version implemented by Gotrix.
-var Version = "v3"
+// SupportedVersions contains versions supported by gotrix.
+var SupportedVersions = map[string]string{
+	"r0.6.0": "r0",
+	"r0.6.1": "r0",
+	"v1.1.0": "v3",
+}
 
-// Known Matrix Client-Server API endpoints.
-//nolint:lll
-var (
-	EndpointBase = "_matrix/client/" + Version
+const EndpointSupportedVersions = "_matrix/client/versions"
 
-	EndpointSupportedVersions = "_matrix/client/versions"
+// Endpoints contains known Matrix Client-Server API endpoints.
+type Endpoints struct {
+	// Version is the Matrix version for these endpoints.
+	Version string
+}
 
-	EndpointUser     = func(id matrix.UserID) string { return EndpointBase + "/user/" + url.PathEscape(string(id)) }
-	EndpointRoom     = func(id matrix.RoomID) string { return EndpointBase + "/rooms/" + url.PathEscape(string(id)) }
-	EndpointUserRoom = func(userID matrix.UserID, roomID matrix.RoomID) string {
-		return EndpointUser(userID) + "/rooms/" + url.PathEscape(string(roomID))
-	}
+func (e Endpoints) Base() string { return "_matrix/client/" + e.Version }
 
-	EndpointLogin     = EndpointBase + "/login"
-	EndpointLogout    = EndpointBase + "/logout"
-	EndpointLogoutAll = EndpointLogout + "/all"
+func (e Endpoints) User(id matrix.UserID) string {
+	return e.Base() + "/user/" + url.PathEscape(string(id))
+}
+func (e Endpoints) Room(id matrix.RoomID) string {
+	return e.Base() + "/rooms/" + url.PathEscape(string(id))
+}
+func (e Endpoints) UserRoom(userID matrix.UserID, roomID matrix.RoomID) string {
+	return e.User(userID) + "/rooms/" + url.PathEscape(string(roomID))
+}
 
-	EndpointRegister             = EndpointBase + "/register"
-	EndpointRegisterAvailable    = EndpointRegister + "/available"
-	EndpointRegisterRequestToken = func(authType string) string { return EndpointRegister + "/" + authType + "/requestToken" }
+func (e Endpoints) Login() string     { return e.Base() + "/login" }
+func (e Endpoints) Logout() string    { return e.Base() + "/logout" }
+func (e Endpoints) LogoutAll() string { return e.Logout() + "/all" }
 
-	EndpointAccount                     = EndpointBase + "/account"
-	EndpointAccountWhoami               = EndpointAccount + "/whoami"
-	EndpointAccountDeactivate           = EndpointAccount + "/deactivate"
-	EndpointAccountPassword             = EndpointAccount + "/password"
-	EndpointAccountPasswordRequestToken = func(authType string) string { return EndpointAccountPassword + "/" + authType + "/requestToken" }
+func (e Endpoints) Register() string          { return e.Base() + "/register" }
+func (e Endpoints) RegisterAvailable() string { return e.Register() + "/available" }
+func (e Endpoints) RegisterRequestToken(authType string) string {
+	return e.Register() + "/" + authType + "/requestToken"
+}
 
-	EndpointAccount3PID             = EndpointAccount + "/3pid"
-	EndpointAccount3PIDAdd          = EndpointAccount3PID + "/add"
-	EndpointAccount3PIDBind         = EndpointAccount3PID + "/bind"
-	EndpointAccount3PIDRequestToken = func(authType string) string { return EndpointAccount3PID + "/" + authType + "/requestToken" }
+func (e Endpoints) Account() string           { return e.Base() + "/account" }
+func (e Endpoints) AccountWhoami() string     { return e.Account() + "/whoami" }
+func (e Endpoints) AccountDeactivate() string { return e.Account() + "/deactivate" }
+func (e Endpoints) AccountPassword() string   { return e.Account() + "/password" }
+func (e Endpoints) AccountPasswordRequestToken(authType string) string {
+	return e.AccountPassword() + "/" + authType + "/requestToken"
+}
 
-	EndpointCapabilities = EndpointBase + "/capabilities"
-	EndpointJoinedRooms  = EndpointBase + "/joined_rooms"
-	EndpointPublicRooms  = EndpointBase + "/publicRooms"
-	EndpointSync         = EndpointBase + "/sync"
+func (e Endpoints) Account3PID() string     { return e.Account() + "/3pid" }
+func (e Endpoints) Account3PIDAdd() string  { return e.Account3PID() + "/add" }
+func (e Endpoints) Account3PIDBind() string { return e.Account3PID() + "/bind" }
+func (e Endpoints) Account3PIDRequestToken(authType string) string {
+	return e.Account3PID() + "/" + authType + "/requestToken"
+}
 
-	EndpointFilter = func(userID matrix.UserID) string {
-		return EndpointUser(userID) + "/filter"
-	}
-	EndpointFilterGet = func(userID matrix.UserID, filterID string) string {
-		return EndpointFilter(userID) + "/" + url.PathEscape(filterID)
-	}
+func (e Endpoints) Capabilities() string { return e.Base() + "/capabilities" }
+func (e Endpoints) JoinedRooms() string  { return e.Base() + "/joined_rooms" }
+func (e Endpoints) PublicRooms() string  { return e.Base() + "/publicRooms" }
+func (e Endpoints) Sync() string         { return e.Base() + "/sync" }
 
-	EndpointRoomCreate        = EndpointBase + "/createRoom"
-	EndpointRoomAliases       = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/aliases" }
-	EndpointRoomBan           = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/ban" }
-	EndpointRoomForget        = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/forget" }
-	EndpointRoomInvite        = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/invite" }
-	EndpointRoomJoin          = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/join" }
-	EndpointRoomJoinedMembers = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/joined_members" }
-	EndpointRoomKick          = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/kick" }
-	EndpointRoomLeave         = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/leave" }
-	EndpointRoomMembers       = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/members" }
-	EndpointRoomMessages      = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/messages" }
-	EndpointRoomState         = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/state" }
-	EndpointRoomUnban         = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/unban" }
-	EndpointRoomUpgrade       = func(roomID matrix.RoomID) string { return EndpointRoom(roomID) + "/upgrade" }
-	EndpointRoomEvent         = func(roomID matrix.RoomID, eventID matrix.EventID) string {
-		return EndpointRoom(roomID) + "/event/" + url.PathEscape(string(eventID))
-	}
-	EndpointRoomStateExact = func(roomID matrix.RoomID, eventType event.Type, stateKey string) string {
-		return EndpointRoomState(roomID) + "/" + url.PathEscape(string(eventType)) + "/" + url.PathEscape(stateKey)
-	}
-	EndpointRoomReceipt = func(roomID matrix.RoomID, receiptType ReceiptType, eventID matrix.EventID) string {
-		return EndpointRoomState(roomID) + "/" + url.PathEscape(string(receiptType)) + "/" + url.PathEscape(string(eventID))
-	}
-	EndpointRoomRedact = func(roomID matrix.RoomID, eventID matrix.EventID, transactionID string) string {
-		return EndpointRoom(roomID) + "/redact/" + url.PathEscape(string(eventID)) + "/" + url.PathEscape(transactionID)
-	}
-	EndpointRoomSend = func(roomID matrix.RoomID, eventType event.Type, transactionID string) string {
-		return EndpointRoom(roomID) + "/send/" + url.PathEscape(string(eventType)) + "/" + url.PathEscape(transactionID)
-	}
-	EndpointRoomTyping = func(roomID matrix.RoomID, userID matrix.UserID) string {
-		return EndpointRoom(roomID) + "/typing/" + url.PathEscape(string(userID))
-	}
+func (e Endpoints) Filter(userID matrix.UserID) string {
+	return e.User(userID) + "/filter"
+}
+func (e Endpoints) FilterGet(userID matrix.UserID, filterID string) string {
+	return e.Filter(userID) + "/" + url.PathEscape(filterID)
+}
 
-	EndpointDirectory          = EndpointBase + "/directory"
-	EndpointDirectoryRoomAlias = func(roomAlias string) string { return EndpointDirectory + "/room/" + url.PathEscape(roomAlias) }
-	EndpointDirectoryListRoom  = func(roomID matrix.RoomID) string {
-		return EndpointDirectory + "/list/room/" + url.PathEscape(string(roomID))
-	}
+func (e Endpoints) RoomCreate() string                      { return e.Base() + "/createRoom" }
+func (e Endpoints) RoomAliases(roomID matrix.RoomID) string { return e.Room(roomID) + "/aliases" }
+func (e Endpoints) RoomBan(roomID matrix.RoomID) string     { return e.Room(roomID) + "/ban" }
+func (e Endpoints) RoomForget(roomID matrix.RoomID) string  { return e.Room(roomID) + "/forget" }
+func (e Endpoints) RoomInvite(roomID matrix.RoomID) string  { return e.Room(roomID) + "/invite" }
+func (e Endpoints) RoomJoin(roomID matrix.RoomID) string    { return e.Room(roomID) + "/join" }
+func (e Endpoints) RoomJoinedMembers(roomID matrix.RoomID) string {
+	return e.Room(roomID) + "/joined_members"
+}
+func (e Endpoints) RoomKick(roomID matrix.RoomID) string    { return e.Room(roomID) + "/kick" }
+func (e Endpoints) RoomLeave(roomID matrix.RoomID) string   { return e.Room(roomID) + "/leave" }
+func (e Endpoints) RoomMembers(roomID matrix.RoomID) string { return e.Room(roomID) + "/members" }
+func (e Endpoints) RoomMessages(roomID matrix.RoomID) string {
+	return e.Room(roomID) + "/messages"
+}
+func (e Endpoints) RoomState(roomID matrix.RoomID) string   { return e.Room(roomID) + "/state" }
+func (e Endpoints) RoomUnban(roomID matrix.RoomID) string   { return e.Room(roomID) + "/unban" }
+func (e Endpoints) RoomUpgrade(roomID matrix.RoomID) string { return e.Room(roomID) + "/upgrade" }
+func (e Endpoints) RoomEvent(roomID matrix.RoomID, eventID matrix.EventID) string {
+	return e.Room(roomID) + "/event/" + url.PathEscape(string(eventID))
+}
+func (e Endpoints) RoomStateExact(roomID matrix.RoomID, eventType event.Type, stateKey string) string {
+	return e.RoomState(roomID) + "/" + url.PathEscape(string(eventType)) + "/" + url.PathEscape(stateKey)
+}
+func (e Endpoints) RoomReceipt(roomID matrix.RoomID, receiptType ReceiptType, eventID matrix.EventID) string {
+	return e.RoomState(roomID) + "/" + url.PathEscape(string(receiptType)) + "/" + url.PathEscape(string(eventID))
+}
+func (e Endpoints) RoomRedact(roomID matrix.RoomID, eventID matrix.EventID, transactionID string) string {
+	return e.Room(roomID) + "/redact/" + url.PathEscape(string(eventID)) + "/" + url.PathEscape(transactionID)
+}
+func (e Endpoints) RoomSend(roomID matrix.RoomID, eventType event.Type, transactionID string) string {
+	return e.Room(roomID) + "/send/" + url.PathEscape(string(eventType)) + "/" + url.PathEscape(transactionID)
+}
+func (e Endpoints) RoomTyping(roomID matrix.RoomID, userID matrix.UserID) string {
+	return e.Room(roomID) + "/typing/" + url.PathEscape(string(userID))
+}
 
-	EndpointUserDirectorySearch = EndpointBase + "/user_directory/search"
+func (e Endpoints) Directory() string { return e.Base() + "/directory" }
+func (e Endpoints) DirectoryRoomAlias(roomAlias string) string {
+	return e.Directory() + "/room/" + url.PathEscape(roomAlias)
+}
+func (e Endpoints) DirectoryListRoom(roomID matrix.RoomID) string {
+	return e.Directory() + "/list/room/" + url.PathEscape(string(roomID))
+}
 
-	EndpointProfile            = func(userID matrix.UserID) string { return EndpointBase + "/profile/" + url.PathEscape(string(userID)) }
-	EndpointProfileAvatarURL   = func(userID matrix.UserID) string { return EndpointProfile(userID) + "/avatar_url" }
-	EndpointProfileDisplayName = func(userID matrix.UserID) string { return EndpointProfile(userID) + "/displayname" }
+func (e Endpoints) UserDirectorySearch() string { return e.Base() + "/user_directory/search" }
 
-	EndpointMedia           = "_matrix/media/" + Version
-	EndpointMediaConfig     = EndpointMedia + "/config"
-	EndpointMediaPreviewURL = EndpointMedia + "/preview_url"
-	EndpointMediaUpload     = EndpointMedia + "/upload"
-	EndpointMediaDownload   = func(serverName string, mediaID string, fileName string) string {
-		return EndpointMedia + "/download/" + url.PathEscape(serverName) + "/" + url.PathEscape(mediaID) + "/" +
-			url.PathEscape(fileName)
-	}
-	EndpointMediaThumbnail = func(serverName string, mediaID string) string {
-		return EndpointMedia + "/thumbnail/" + url.PathEscape(serverName) + "/" + url.PathEscape(mediaID)
-	}
+func (e Endpoints) Profile(userID matrix.UserID) string {
+	return e.Base() + "/profile/" + url.PathEscape(string(userID))
+}
+func (e Endpoints) ProfileAvatarURL(userID matrix.UserID) string {
+	return e.Profile(userID) + "/avatar_url"
+}
+func (e Endpoints) ProfileDisplayName(userID matrix.UserID) string {
+	return e.Profile(userID) + "/displayname"
+}
 
-	EndpointVOIPTURNServers = EndpointMedia + "/voip/turnServer"
+func (e Endpoints) Media() string           { return "_matrix/media/" + e.Version }
+func (e Endpoints) MediaConfig() string     { return e.Media() + "/config" }
+func (e Endpoints) MediaPreviewURL() string { return e.Media() + "/preview_url" }
+func (e Endpoints) MediaUpload() string     { return e.Media() + "/upload" }
+func (e Endpoints) MediaDownload(serverName string, mediaID string, fileName string) string {
+	return e.Media() + "/download/" + url.PathEscape(serverName) + "/" + url.PathEscape(mediaID) + "/" +
+		url.PathEscape(fileName)
+}
+func (e Endpoints) MediaThumbnail(serverName string, mediaID string) string {
+	return e.Media() + "/thumbnail/" + url.PathEscape(serverName) + "/" + url.PathEscape(mediaID)
+}
 
-	EndpointPresenceStatus = func(userID matrix.UserID) string {
-		return EndpointBase + "/presence/" + url.PathEscape(string(userID)) + "/status"
-	}
+func (e Endpoints) VOIPTURNServers() string { return e.Media() + "/voip/turnServer" }
 
-	EndpointAccountDataGlobal = func(userID matrix.UserID, dataType string) string {
-		return EndpointUser(userID) + "/account_data/" + url.PathEscape(dataType)
-	}
-	EndpointAccountDataRoom = func(userID matrix.UserID, roomID matrix.RoomID, dataType string) string {
-		return EndpointUserRoom(userID, roomID) + "/account_data/" + url.PathEscape(dataType)
-	}
+func (e Endpoints) PresenceStatus(userID matrix.UserID) string {
+	return e.Base() + "/presence/" + url.PathEscape(string(userID)) + "/status"
+}
 
-	EndpointSendToDevice = func(eventType event.Type, transactionID string) string {
-		return EndpointBase + "/sendToDevice/" + url.PathEscape(string(eventType)) + "/" + url.PathEscape(transactionID)
-	}
+func (e Endpoints) AccountDataGlobal(userID matrix.UserID, dataType string) string {
+	return e.User(userID) + "/account_data/" + url.PathEscape(dataType)
+}
+func (e Endpoints) AccountDataRoom(userID matrix.UserID, roomID matrix.RoomID, dataType string) string {
+	return e.UserRoom(userID, roomID) + "/account_data/" + url.PathEscape(dataType)
+}
 
-	EndpointTags = func(userID matrix.UserID, roomID matrix.RoomID) string {
-		return EndpointUserRoom(userID, roomID) + "/tags"
-	}
+func (e Endpoints) SendToDevice(eventType event.Type, transactionID string) string {
+	return e.Base() + "/sendToDevice/" + url.PathEscape(string(eventType)) + "/" + url.PathEscape(transactionID)
+}
 
-	EndpointTag = func(userID matrix.UserID, roomID matrix.RoomID, name matrix.TagName) string {
-		return EndpointTags(userID, roomID) + "/" + url.PathEscape(string(name))
-	}
+func (e Endpoints) Tags(userID matrix.UserID, roomID matrix.RoomID) string {
+	return e.UserRoom(userID, roomID) + "/tags"
+}
 
-	EndpointSSOLogin = func(redirectURL string) string {
-		return EndpointBase + "/login/sso/redirect?redirectUrl=" + url.QueryEscape(redirectURL)
-	}
-)
+func (e Endpoints) Tag(userID matrix.UserID, roomID matrix.RoomID, name matrix.TagName) string {
+	return e.Tags(userID, roomID) + "/" + url.PathEscape(string(name))
+}
+
+func (e Endpoints) SSOLogin(redirectURL string) string {
+	return e.Base() + "/login/sso/redirect?redirectUrl=" + url.QueryEscape(redirectURL)
+}

--- a/api/filter.go
+++ b/api/filter.go
@@ -14,7 +14,7 @@ func (c *Client) FilterAdd(filterToUpload event.GlobalFilter) (string, error) {
 		FilterID string `json:"filter_id"`
 	}
 	err := c.Request(
-		"POST", EndpointFilter(c.UserID), &resp,
+		"POST", c.Endpoints.Filter(c.UserID), &resp,
 		httputil.WithToken(), httputil.WithJSONBody(filterToUpload),
 	)
 	if err != nil {
@@ -27,7 +27,7 @@ func (c *Client) FilterAdd(filterToUpload event.GlobalFilter) (string, error) {
 func (c *Client) Filter(filterID string) (*event.GlobalFilter, error) {
 	resp := &event.GlobalFilter{}
 	err := c.Request(
-		"GET", EndpointFilterGet(c.UserID, filterID), resp,
+		"GET", c.Endpoints.FilterGet(c.UserID, filterID), resp,
 		httputil.WithToken(),
 	)
 	if err != nil {

--- a/api/media.go
+++ b/api/media.go
@@ -18,7 +18,7 @@ func (c *Client) MediaUpload(contentType string, filename string, body io.ReadCl
 		ContentURI matrix.URL `json:"content_uri"`
 	}
 	err := c.Request(
-		"POST", EndpointMediaUpload, &resp,
+		"POST", c.Endpoints.MediaUpload(), &resp,
 		httputil.WithToken(),
 		httputil.WithHeader(map[string][]string{
 			"Content-Type": {
@@ -50,7 +50,7 @@ func (c *Client) MediaDownloadURL(matrixURL matrix.URL, allowRemote bool, filena
 
 	parsed.Path = strings.TrimPrefix(parsed.Path, "/")
 
-	return c.FullRoute(EndpointMediaDownload(parsed.Host, parsed.Path, filename)) +
+	return c.FullRoute(c.Endpoints.MediaDownload(parsed.Host, parsed.Path, filename)) +
 			"?allow_remote=" + strconv.FormatBool(allowRemote),
 		nil
 }
@@ -87,7 +87,7 @@ func (c *Client) MediaThumbnailURL(matrixURL matrix.URL, allowRemote bool,
 		"allow_remote": {strconv.FormatBool(allowRemote)},
 	}
 
-	return c.FullRoute(EndpointMediaThumbnail(parsed.Host, parsed.Path)) + "?" + query.Encode(), nil
+	return c.FullRoute(c.Endpoints.MediaThumbnail(parsed.Host, parsed.Path)) + "?" + query.Encode(), nil
 }
 
 // URLMetadata contains the basic OpenGraph metadata that the Matrix backend
@@ -144,7 +144,7 @@ func (c *Client) PreviewURL(url string, ts matrix.Timestamp) (*URLMetadata, erro
 
 	var resp *URLMetadata
 	err := c.Request(
-		"GET", EndpointMediaPreviewURL, &resp,
+		"GET", c.Endpoints.MediaPreviewURL(), &resp,
 		httputil.WithToken(), httputil.WithQuery(query),
 	)
 	if err != nil {
@@ -164,7 +164,7 @@ type MediaConfig struct {
 func (c *Client) MediaConfig() (MediaConfig, error) {
 	var resp MediaConfig
 	err := c.Request(
-		"GET", EndpointMediaConfig, &resp,
+		"GET", c.Endpoints.MediaConfig(), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {

--- a/api/presence.go
+++ b/api/presence.go
@@ -19,7 +19,7 @@ type Presence struct {
 func (c *Client) Presence(userID matrix.UserID) (Presence, error) {
 	var resp Presence
 	err := c.Request(
-		"GET", EndpointPresenceStatus(userID), &resp,
+		"GET", c.Endpoints.PresenceStatus(userID), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -39,7 +39,7 @@ func (c *Client) PresenceSet(presence matrix.Presence, statusMsg string) error {
 	}
 
 	err := c.Request(
-		"PUT", EndpointPresenceStatus(c.UserID), nil,
+		"PUT", c.Endpoints.PresenceStatus(c.UserID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {

--- a/api/query.go
+++ b/api/query.go
@@ -14,7 +14,7 @@ import (
 func (c *Client) RoomEvent(roomID matrix.RoomID, eventID matrix.EventID) (event.RawEvent, error) {
 	var resp event.RawEvent
 	err := c.Request(
-		"GET", EndpointRoomEvent(roomID, eventID), &resp,
+		"GET", c.Endpoints.RoomEvent(roomID, eventID), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -27,7 +27,7 @@ func (c *Client) RoomEvent(roomID matrix.RoomID, eventID matrix.EventID) (event.
 func (c *Client) RoomState(roomID matrix.RoomID, eventType event.Type, key string) (event.RawEvent, error) {
 	var content json.RawMessage
 	err := c.Request(
-		"GET", EndpointRoomStateExact(roomID, eventType, key), &content,
+		"GET", c.Endpoints.RoomStateExact(roomID, eventType, key), &content,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -56,7 +56,7 @@ func (c *Client) RoomState(roomID matrix.RoomID, eventType event.Type, key strin
 func (c *Client) RoomStates(roomID matrix.RoomID) ([]event.RawEvent, error) {
 	resp := []event.RawEvent{}
 	err := c.Request(
-		"GET", EndpointRoomState(roomID), &resp,
+		"GET", c.Endpoints.RoomState(roomID), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -92,7 +92,7 @@ func (c *Client) RoomMembers(roomID matrix.RoomID, filter RoomMemberFilter) ([]e
 	}
 
 	err := c.Request(
-		"GET", EndpointRoomMembers(roomID), &resp,
+		"GET", c.Endpoints.RoomMembers(roomID), &resp,
 		httputil.WithToken(), httputil.WithQuery(arg),
 	)
 	if err != nil {
@@ -111,7 +111,7 @@ type RoomMember struct {
 func (c *Client) RoomJoinedMembers(roomID matrix.RoomID) (map[matrix.UserID]RoomMember, error) {
 	var resp map[matrix.UserID]RoomMember
 	err := c.Request(
-		"GET", EndpointRoomJoinedMembers(roomID), &resp,
+		"GET", c.Endpoints.RoomJoinedMembers(roomID), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -169,7 +169,7 @@ func (c *Client) RoomMessages(roomID matrix.RoomID, query RoomMessagesQuery) (Ro
 
 	var resp RoomMessagesResponse
 	err := c.Request(
-		"GET", EndpointRoomMessages(roomID), &resp,
+		"GET", c.Endpoints.RoomMessages(roomID), &resp,
 		httputil.WithToken(), httputil.WithQuery(arg),
 	)
 	if err != nil {

--- a/api/receipt.go
+++ b/api/receipt.go
@@ -15,7 +15,7 @@ const ReceiptRead ReceiptType = "m.read"
 // ReceiptMarkerUpdate updates the location of receipt marker to the event ID specified.
 func (c *Client) ReceiptMarkerUpdate(roomID matrix.RoomID, receiptType ReceiptType, eventID matrix.EventID) error {
 	err := c.Request(
-		"POST", EndpointRoomReceipt(roomID, receiptType, eventID), nil,
+		"POST", c.Endpoints.RoomReceipt(roomID, receiptType, eventID), nil,
 	)
 	if err != nil {
 		return fmt.Errorf("error updating receipt marker location: %w", err)

--- a/api/register.go
+++ b/api/register.go
@@ -39,7 +39,7 @@ func (c *Client) Register(kind string, req RegisterArg) (InteractiveRegister, er
 	ir.Request = func(auth, to interface{}) error {
 		req.Auth = auth
 		err := c.Request(
-			"POST", EndpointRegister, to,
+			"POST", c.Endpoints.Register(), to,
 			httputil.WithJSONBody(req), httputil.WithQuery(map[string]string{
 				"kind": kind,
 			}),
@@ -49,7 +49,7 @@ func (c *Client) Register(kind string, req RegisterArg) (InteractiveRegister, er
 
 	ir.RequestThreePID = func(authType string, auth, to interface{}) error {
 		return c.Request(
-			"POST", EndpointRegisterRequestToken(authType), to,
+			"POST", c.Endpoints.RegisterRequestToken(authType), to,
 			httputil.WithJSONBody(auth),
 		)
 	}
@@ -99,7 +99,7 @@ func (i InteractiveRegister) RegisterResponse() (*RegisterResponse, error) {
 // between UsernameAvailable() and actual registration.
 func (c *Client) UsernameAvailable(username string) (bool, error) {
 	err := c.Request(
-		"GET", EndpointRegisterAvailable, nil,
+		"GET", c.Endpoints.RegisterAvailable(), nil,
 		httputil.WithQuery(map[string]string{
 			"username": username,
 		}),

--- a/api/room.go
+++ b/api/room.go
@@ -65,7 +65,7 @@ func (c *Client) RoomCreate(arg RoomCreateArg) (matrix.RoomID, error) {
 		RoomID matrix.RoomID `json:"room_id"`
 	}{}
 	err := c.Request(
-		"POST", EndpointRoomCreate, resp,
+		"POST", c.Endpoints.RoomCreate(), resp,
 		httputil.WithToken(), httputil.WithJSONBody(arg),
 	)
 	if err != nil {

--- a/api/room_alias.go
+++ b/api/room_alias.go
@@ -17,7 +17,7 @@ type RoomAliasResponse struct {
 func (c *Client) RoomAlias(alias string) (RoomAliasResponse, error) {
 	var resp RoomAliasResponse
 	err := c.Request(
-		"GET", EndpointDirectoryRoomAlias(alias), &resp,
+		"GET", c.Endpoints.DirectoryRoomAlias(alias), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -32,7 +32,7 @@ func (c *Client) RoomAliases(roomID matrix.RoomID) ([]string, error) {
 		Aliases []string `json:"aliases"`
 	}
 	err := c.Request(
-		"GET", EndpointRoomAliases(roomID), &resp,
+		"GET", c.Endpoints.RoomAliases(roomID), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -49,7 +49,7 @@ func (c *Client) RoomAliasCreate(alias string, roomID matrix.RoomID) error {
 		RoomID: roomID,
 	}
 	err := c.Request(
-		"PUT", EndpointDirectoryRoomAlias(alias), nil,
+		"PUT", c.Endpoints.DirectoryRoomAlias(alias), nil,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {
@@ -61,7 +61,7 @@ func (c *Client) RoomAliasCreate(alias string, roomID matrix.RoomID) error {
 // RoomAliasDelete deletes a room alias.
 func (c *Client) RoomAliasDelete(alias string) error {
 	err := c.Request(
-		"DELETE", EndpointDirectoryRoomAlias(alias), nil,
+		"DELETE", c.Endpoints.DirectoryRoomAlias(alias), nil,
 		httputil.WithToken(),
 	)
 	if err != nil {

--- a/api/room_list.go
+++ b/api/room_list.go
@@ -14,7 +14,7 @@ func (c *Client) RoomVisibility(roomID matrix.RoomID) (RoomVisibility, error) {
 		Visibility RoomVisibility `json:"visibility"`
 	}
 
-	err := c.Request("GET", EndpointDirectoryListRoom(roomID), &resp)
+	err := c.Request("GET", c.Endpoints.DirectoryListRoom(roomID), &resp)
 	if err != nil {
 		return "", fmt.Errorf("error fetching room visibility: %w", err)
 	}
@@ -28,7 +28,7 @@ func (c *Client) RoomVisibilitySet(roomID matrix.RoomID, newVisibility RoomVisib
 	}{newVisibility}
 
 	err := c.Request(
-		"GET", EndpointDirectoryListRoom(roomID), nil,
+		"GET", c.Endpoints.DirectoryListRoom(roomID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {
@@ -81,7 +81,7 @@ func (c *Client) PublicRooms(limit int, since string, server string) (PublicRoom
 
 	var resp PublicRoomsResponse
 	err := c.Request(
-		"GET", EndpointPublicRooms, &resp,
+		"GET", c.Endpoints.PublicRooms(), &resp,
 		httputil.WithQuery(req),
 	)
 	if err != nil {
@@ -120,7 +120,7 @@ func (c *Client) PublicRoomsSearch(arg PublicRoomsSearchArg) (PublicRoomsRespons
 
 	var resp PublicRoomsResponse
 	err := c.Request(
-		"POST", EndpointPublicRooms, &resp,
+		"POST", c.Endpoints.PublicRooms(), &resp,
 		httputil.WithQuery(req), httputil.WithJSONBody(arg),
 	)
 	if err != nil {

--- a/api/room_membership.go
+++ b/api/room_membership.go
@@ -13,7 +13,7 @@ func (c *Client) Rooms() ([]matrix.RoomID, error) {
 		JoinedRooms []matrix.RoomID `json:"joined_rooms"`
 	}
 	err := c.Request(
-		"GET", EndpointJoinedRooms, &resp,
+		"GET", c.Endpoints.JoinedRooms(), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -30,7 +30,7 @@ func (c *Client) Invite(roomID matrix.RoomID, userID matrix.UserID, reason strin
 		Reason string        `json:"reason,omitempty"`
 	}{userID, reason}
 	err := c.Request(
-		"POST", EndpointRoomInvite(roomID), nil,
+		"POST", c.Endpoints.RoomInvite(roomID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(body),
 	)
 	if err != nil {
@@ -46,7 +46,7 @@ func (c *Client) RoomJoin(roomID matrix.RoomID, reason string) error {
 		Reason string `json:"reason,omitempty"`
 	}{reason}
 	err := c.Request(
-		"POST", EndpointRoomJoin(roomID), nil,
+		"POST", c.Endpoints.RoomJoin(roomID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(body),
 	)
 	if err != nil {
@@ -64,7 +64,7 @@ func (c *Client) RoomLeave(roomID matrix.RoomID, reason string) error {
 		Reason string `json:"reason,omitempty"`
 	}{reason}
 	err := c.Request(
-		"POST", EndpointRoomLeave(roomID), nil,
+		"POST", c.Endpoints.RoomLeave(roomID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(body),
 	)
 	return err
@@ -75,7 +75,7 @@ func (c *Client) RoomLeave(roomID matrix.RoomID, reason string) error {
 // The client must not be in the room when RoomForget is called.
 func (c *Client) RoomForget(roomID matrix.RoomID) error {
 	err := c.Request(
-		"POST", EndpointRoomForget(roomID), nil,
+		"POST", c.Endpoints.RoomForget(roomID), nil,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -92,7 +92,7 @@ func (c *Client) Kick(roomID matrix.RoomID, userID matrix.UserID, reason string)
 	}{userID, reason}
 
 	err := c.Request(
-		"POST", EndpointRoomKick(roomID), nil,
+		"POST", c.Endpoints.RoomKick(roomID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(param),
 	)
 	if err != nil {
@@ -109,7 +109,7 @@ func (c *Client) Ban(roomID matrix.RoomID, userID matrix.UserID, reason string) 
 	}{userID, reason}
 
 	err := c.Request(
-		"POST", EndpointRoomBan(roomID), nil,
+		"POST", c.Endpoints.RoomBan(roomID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(param),
 	)
 	if err != nil {
@@ -127,7 +127,7 @@ func (c *Client) Unban(roomID matrix.RoomID, userID matrix.UserID, reason string
 	}{userID, reason}
 
 	err := c.Request(
-		"POST", EndpointRoomUnban(roomID), nil,
+		"POST", c.Endpoints.RoomUnban(roomID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(param),
 	)
 	if err != nil {

--- a/api/send.go
+++ b/api/send.go
@@ -21,7 +21,7 @@ func (c *Client) RoomStateSend(roomID matrix.RoomID, event RoomStateSendArg) (ma
 		EventID matrix.EventID `json:"event_id"`
 	}
 	err := c.Request(
-		"PUT", EndpointRoomStateExact(roomID, event.Type, event.StateKey), &resp,
+		"PUT", c.Endpoints.RoomStateExact(roomID, event.Type, event.StateKey), &resp,
 		httputil.WithToken(), httputil.WithJSONBody(event.Content),
 	)
 	if err != nil {
@@ -37,7 +37,7 @@ func (c *Client) RoomEventSend(roomID matrix.RoomID, eventType event.Type, body 
 	}
 
 	err := c.Request(
-		"PUT", EndpointRoomSend(roomID, eventType, NextTransactionID()), &resp,
+		"PUT", c.Endpoints.RoomSend(roomID, eventType, NextTransactionID()), &resp,
 		httputil.WithToken(), httputil.WithJSONBody(body),
 	)
 	if err != nil {
@@ -57,7 +57,7 @@ func (c *Client) RoomEventRedact(roomID matrix.RoomID, eventID matrix.EventID, r
 	}
 
 	err := c.Request(
-		"PUT", EndpointRoomRedact(roomID, eventID, NextTransactionID()), &resp,
+		"PUT", c.Endpoints.RoomRedact(roomID, eventID, NextTransactionID()), &resp,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {
@@ -76,7 +76,7 @@ func (c *Client) SendToDevice(eventType event.Type, messages DeviceMessages) err
 	}
 
 	err := c.Request(
-		"PUT", EndpointSendToDevice(eventType, NextTransactionID()), nil,
+		"PUT", c.Endpoints.SendToDevice(eventType, NextTransactionID()), nil,
 		httputil.WithToken(), httputil.WithJSONBody(body),
 	)
 	if err != nil {

--- a/api/sync.go
+++ b/api/sync.go
@@ -118,7 +118,7 @@ func (c *Client) Sync(req SyncArg) (*SyncResponse, error) {
 		args["timeout"] = strconv.Itoa(req.Timeout)
 	}
 	err := c.Request(
-		"GET", EndpointSync, resp,
+		"GET", c.Endpoints.Sync(), resp,
 		httputil.WithToken(), httputil.WithQuery(args),
 	)
 	if err != nil {

--- a/api/tag.go
+++ b/api/tag.go
@@ -16,7 +16,7 @@ func (c *Client) Tags(roomID matrix.RoomID) (map[matrix.TagName]matrix.Tag, erro
 		Tags map[matrix.TagName]matrix.Tag `json:"tags"`
 	}
 	err := c.Request(
-		"GET", EndpointTags(c.UserID, roomID), &resp,
+		"GET", c.Endpoints.Tags(c.UserID, roomID), &resp,
 		httputil.WithToken(),
 	)
 	if err != nil {
@@ -31,7 +31,7 @@ func (c *Client) TagAdd(roomID matrix.RoomID, name matrix.TagName, tagData matri
 		return ErrInvalidTagName
 	}
 	err := c.Request(
-		"PUT", EndpointTag(c.UserID, roomID, name), nil,
+		"PUT", c.Endpoints.Tag(c.UserID, roomID, name), nil,
 		httputil.WithToken(), httputil.WithJSONBody(tagData),
 	)
 	if err != nil {
@@ -46,7 +46,7 @@ func (c *Client) TagDelete(roomID matrix.RoomID, name matrix.TagName) error {
 		return ErrInvalidTagName
 	}
 	err := c.Request(
-		"DELETE", EndpointTag(c.UserID, roomID, name), nil,
+		"DELETE", c.Endpoints.Tag(c.UserID, roomID, name), nil,
 		httputil.WithToken(),
 	)
 	if err != nil {

--- a/api/typing.go
+++ b/api/typing.go
@@ -17,7 +17,7 @@ func (c *Client) TypingStart(roomID matrix.RoomID, timeout time.Duration) error 
 	}
 
 	err := c.Request(
-		"PUT", EndpointRoomTyping(roomID, c.UserID), nil,
+		"PUT", c.Endpoints.RoomTyping(roomID, c.UserID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {
@@ -33,7 +33,7 @@ func (c *Client) TypingStop(roomID matrix.RoomID) error {
 	}
 
 	err := c.Request(
-		"PUT", EndpointRoomTyping(roomID, c.UserID), nil,
+		"PUT", c.Endpoints.RoomTyping(roomID, c.UserID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {

--- a/api/upgrade.go
+++ b/api/upgrade.go
@@ -16,7 +16,7 @@ func (c *Client) UpgradeRoom(roomID matrix.RoomID, newVersion string) (matrix.Ro
 		ReplacementRoom matrix.RoomID `json:"replacement_room"`
 	}
 	err := c.Request(
-		"POST", EndpointRoomUpgrade(roomID), &resp,
+		"POST", c.Endpoints.RoomUpgrade(roomID), &resp,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {

--- a/api/user.go
+++ b/api/user.go
@@ -30,7 +30,7 @@ func (c *Client) UserSearch(keyword string, limit int) (result []User, limited b
 	}
 
 	err = c.Request(
-		"POST", EndpointUserDirectorySearch, &resp,
+		"POST", c.Endpoints.UserDirectorySearch(), &resp,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {
@@ -46,7 +46,7 @@ func (c *Client) User(userID matrix.UserID) (User, error) {
 		ID: userID,
 	}
 	err := c.Request(
-		"GET", EndpointProfile(userID), &resp,
+		"GET", c.Endpoints.Profile(userID), &resp,
 	)
 	if err != nil {
 		return User{}, fmt.Errorf("error fetching user info: %w", err)
@@ -60,7 +60,7 @@ func (c *Client) DisplayName(userID matrix.UserID) (*string, error) {
 		DisplayName *string `json:"displayname,omitempty"`
 	}
 	err := c.Request(
-		"GET", EndpointProfileDisplayName(userID), &resp,
+		"GET", c.Endpoints.ProfileDisplayName(userID), &resp,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching display name: %w", err)
@@ -75,7 +75,7 @@ func (c *Client) DisplayNameSet(displayName string) error {
 	}
 
 	err := c.Request(
-		"PUT", EndpointProfileDisplayName(c.UserID), nil,
+		"PUT", c.Endpoints.ProfileDisplayName(c.UserID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {
@@ -90,7 +90,7 @@ func (c *Client) AvatarURL(userID matrix.UserID) (*matrix.URL, error) {
 		AvatarURL *matrix.URL `json:"avatar_url,omitempty"`
 	}
 	err := c.Request(
-		"GET", EndpointProfileAvatarURL(userID), &resp,
+		"GET", c.Endpoints.ProfileAvatarURL(userID), &resp,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching avatar URL: %w", err)
@@ -105,7 +105,7 @@ func (c *Client) AvatarURLSet(avatarURL matrix.URL) error {
 	}
 
 	err := c.Request(
-		"PUT", EndpointProfileAvatarURL(c.UserID), nil,
+		"PUT", c.Endpoints.ProfileAvatarURL(c.UserID), nil,
 		httputil.WithToken(), httputil.WithJSONBody(req),
 	)
 	if err != nil {

--- a/api/voip.go
+++ b/api/voip.go
@@ -19,7 +19,7 @@ type TURNServersResponse struct {
 func (c *Client) TURNServers() (TURNServersResponse, error) {
 	var resp TURNServersResponse
 	err := c.Request(
-		"GET", EndpointVOIPTURNServers, resp,
+		"GET", c.Endpoints.VOIPTURNServers(), resp,
 		httputil.WithToken(),
 	)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -46,10 +46,16 @@ func NewWithClient(httpClient httputil.Client, serverName string) (*Client, erro
 	}
 
 	apiClient := &api.Client{
-		Client: httpClient,
+		Client:    httpClient,
+		Endpoints: api.Endpoints{Version: "r0"},
 	}
 	apiClient.HomeServer = parsed.Host
 	apiClient.HomeServerScheme = parsed.Scheme
+
+	if vClient, err := apiClient.WithLatestVersion(); err == nil {
+		apiClient = vClient
+	}
+
 	return &Client{
 		Client:   apiClient,
 		SyncOpts: DefaultSyncOptions,

--- a/sso.go
+++ b/sso.go
@@ -6,8 +6,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-
-	"github.com/chanbakjsd/gotrix/api"
 )
 
 //go:embed sso_success.html
@@ -46,7 +44,7 @@ func (c *Client) LoginSSO() (string, func() error, error) {
 
 	port := listener.Addr().(*net.TCPAddr).Port
 	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/"
-	ssoURL := c.FullRoute(api.EndpointSSOLogin(url))
+	ssoURL := c.FullRoute(c.Client.Endpoints.SSOLogin(url))
 
 	success := make(chan string)
 	errChannel := make(chan error)


### PR DESCRIPTION
This PR adds partial multiversioning support for Matrix endpoints.

Note that this will cause gotrix to use the r0 version for the matrix.org instance, because Synapse doesn't fully implement the v3 specs yet.